### PR TITLE
Add authentication layer with phone-based login (Phase 4)

### DIFF
--- a/src/app/api/delivery/assignments/[id]/route.ts
+++ b/src/app/api/delivery/assignments/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { getAuthenticatedUser, unauthorizedResponse } from '@/lib/auth/guard';
 import type { DeliveryAssignmentStatus, OrderStatus, DeliveryAssignment, Order } from '@/lib/supabase/types';
 
 // Map assignment status to order status (for picked_up and delivered only)
@@ -14,6 +15,9 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const { error: authError, isDemoMode } = await getAuthenticatedUser();
+    if (!isDemoMode && authError) return unauthorizedResponse();
+
     const { id } = await params;
     const supabase = await createClient();
     const body = await request.json();
@@ -112,6 +116,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const { error: authError, isDemoMode } = await getAuthenticatedUser();
+    if (!isDemoMode && authError) return unauthorizedResponse();
+
     const { id } = await params;
     const supabase = await createClient();
 

--- a/src/app/api/delivery/assignments/route.ts
+++ b/src/app/api/delivery/assignments/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { getAuthenticatedUser, unauthorizedResponse } from '@/lib/auth/guard';
 
 export async function GET(request: NextRequest) {
   try {
+    const { error: authError, isDemoMode } = await getAuthenticatedUser();
+    if (!isDemoMode && authError) return unauthorizedResponse();
+
     const supabase = await createClient();
     const { searchParams } = new URL(request.url);
 

--- a/src/app/api/orders/[id]/status/route.ts
+++ b/src/app/api/orders/[id]/status/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { getAuthenticatedUser, unauthorizedResponse } from '@/lib/auth/guard';
 import type { OrderStatus, Order, DeliveryAssignment } from '@/lib/supabase/types';
 
 // Valid status transitions
@@ -18,6 +19,9 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const { error: authError, isDemoMode } = await getAuthenticatedUser();
+    if (!isDemoMode && authError) return unauthorizedResponse();
+
     const { id } = await params;
     const supabase = await createClient();
     const body = await request.json();
@@ -120,6 +124,9 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const { error: authError, isDemoMode } = await getAuthenticatedUser();
+    if (!isDemoMode && authError) return unauthorizedResponse();
+
     const { id } = await params;
     const supabase = await createClient();
 

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,13 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { getAuthenticatedUser, unauthorizedResponse } from '@/lib/auth/guard';
 import type { Order, DeliveryPerson } from '@/lib/supabase/types';
 
 export async function POST(request: NextRequest) {
   try {
+    const { user: authUser, error: authError, isDemoMode } = await getAuthenticatedUser();
+    if (!isDemoMode && authError) return unauthorizedResponse();
+
     const supabase = await createClient();
     const body = await request.json();
 
-    const { vendor_id, items, delivery_address, delivery_notes, customer_id } = body;
+    const { vendor_id, items, delivery_address, delivery_notes, customer_id: bodyCustomerId } = body;
+    const customer_id = isDemoMode ? bodyCustomerId : authUser!.id;
 
     // Validate required fields
     if (!vendor_id || !items?.length || !delivery_address || !customer_id) {
@@ -109,6 +114,9 @@ export async function POST(request: NextRequest) {
 
 export async function GET(request: NextRequest) {
   try {
+    const { error: authError, isDemoMode } = await getAuthenticatedUser();
+    if (!isDemoMode && authError) return unauthorizedResponse();
+
     const supabase = await createClient();
     const { searchParams } = new URL(request.url);
 

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -9,11 +9,12 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { useCart } from '@/hooks/use-cart';
-import { DEMO_IDS } from '@/lib/config/demo';
+import { useAuth } from '@/hooks/use-auth';
 
 export default function CheckoutPage() {
   const router = useRouter();
   const { items, totalAmount, vendorId, clearCart } = useCart();
+  const { userId } = useAuth();
   const [address, setAddress] = useState('');
   const [notes, setNotes] = useState('');
   const [loading, setLoading] = useState(false);
@@ -40,7 +41,7 @@ export default function CheckoutPage() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          customer_id: DEMO_IDS.CUSTOMER_ID,
+          customer_id: userId,
           vendor_id: vendorId,
           items: items.map((item) => ({
             menu_item_id: item.menu_item_id,

--- a/src/app/delivery/page.tsx
+++ b/src/app/delivery/page.tsx
@@ -8,7 +8,7 @@ import { Separator } from '@/components/ui/separator';
 import { OrderStatusBadge } from '@/components/order-status';
 import { useDeliveryAssignments, updateAssignmentStatus } from '@/hooks/use-orders';
 import type { DeliveryAssignment, OrderWithDetails } from '@/lib/supabase/types';
-import { DEMO_IDS } from '@/lib/config/demo';
+import { useAuth } from '@/hooks/use-auth';
 
 // Extended order type with vendor_accepted
 interface DeliveryOrder extends OrderWithDetails {
@@ -16,7 +16,8 @@ interface DeliveryOrder extends OrderWithDetails {
 }
 
 export default function DeliveryDashboard() {
-  const { assignments, loading, error } = useDeliveryAssignments(DEMO_IDS.DELIVERY_PERSON_ID);
+  const { deliveryPersonId } = useAuth();
+  const { assignments, loading, error } = useDeliveryAssignments(deliveryPersonId!);
   const [updating, setUpdating] = useState<string | null>(null);
 
   const handleStatusUpdate = async (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { RoleProvider } from "@/hooks/use-role";
+import { AuthProvider } from "@/hooks/use-auth";
 import { CartProvider } from "@/hooks/use-cart";
 
 const geistSans = Geist({
@@ -43,9 +44,11 @@ export default function RootLayout({
           </div>
         )}
         <RoleProvider>
-          <CartProvider>
-            {children}
-          </CartProvider>
+          <AuthProvider>
+            <CartProvider>
+              {children}
+            </CartProvider>
+          </AuthProvider>
         </RoleProvider>
       </body>
     </html>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { Suspense, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { Phone, Lock, Loader2 } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useAuth } from '@/hooks/use-auth';
+import { DEMO_MODE } from '@/lib/config/demo';
+
+function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { signIn } = useAuth();
+  const [phone, setPhone] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Demo mode doesn't need login
+  if (DEMO_MODE) {
+    router.push('/');
+    return null;
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!phone.trim() || !password) return;
+
+    setLoading(true);
+    setError(null);
+
+    const { error: signInError } = await signIn(phone.trim(), password);
+
+    if (signInError) {
+      setError(signInError);
+      setLoading(false);
+    } else {
+      const redirect = searchParams.get('redirect') || '/';
+      router.push(redirect);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center px-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">Sign In</CardTitle>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            Welcome back to Firefly
+          </p>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium flex items-center gap-2">
+                <Phone className="w-4 h-4" />
+                Phone Number
+              </label>
+              <Input
+                type="tel"
+                placeholder="+1 555 000 0000"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                className="h-12"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium flex items-center gap-2">
+                <Lock className="w-4 h-4" />
+                Password
+              </label>
+              <Input
+                type="password"
+                placeholder="Enter your password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="h-12"
+                required
+              />
+            </div>
+
+            {error && (
+              <div className="p-3 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-lg text-sm text-center">
+                {error}
+              </div>
+            )}
+
+            <Button
+              type="submit"
+              className="w-full bg-green-600 hover:bg-green-700 h-12 text-base"
+              disabled={loading}
+            >
+              {loading ? (
+                <>
+                  <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+                  Signing in...
+                </>
+              ) : (
+                'Sign In'
+              )}
+            </Button>
+          </form>
+
+          <p className="text-center text-sm text-gray-500 dark:text-gray-400 mt-6">
+            Don&apos;t have an account?{' '}
+            <Link
+              href="/register"
+              className="text-green-600 hover:text-green-700 font-medium"
+            >
+              Create one
+            </Link>
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { ShoppingBag, Store, Truck } from "lucide-react";
+import { DEMO_MODE } from "@/lib/config/demo";
 
 const roles = [
   {
@@ -33,6 +35,60 @@ const roles = [
 ];
 
 export default function Home() {
+  if (!DEMO_MODE) {
+    return (
+      <div className="min-h-screen bg-background">
+        <header className="border-b bg-background">
+          <div className="container flex h-16 items-center justify-center px-4">
+            <h1 className="text-2xl font-bold">Project Firefly</h1>
+          </div>
+        </header>
+
+        <main className="container px-4 py-8">
+          <div className="mx-auto max-w-md space-y-8 text-center">
+            <div className="space-y-2">
+              <p className="text-lg text-muted-foreground">
+                Community-powered food ordering for local co-ops
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Order from local vendors, delivered by your neighbors
+              </p>
+            </div>
+
+            <div className="grid grid-cols-3 gap-4">
+              {roles.map((role) => (
+                <div key={role.name} className="text-center">
+                  <div className={`mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full ${role.color} text-white`}>
+                    <role.icon className="h-6 w-6" />
+                  </div>
+                  <p className="text-sm font-medium">{role.name}</p>
+                </div>
+              ))}
+            </div>
+
+            <div className="space-y-3">
+              <Link href="/login">
+                <Button className="w-full bg-green-600 hover:bg-green-700 h-12 text-base">
+                  Sign In
+                </Button>
+              </Link>
+              <Link href="/register">
+                <Button variant="outline" className="w-full h-12 text-base">
+                  Create Account
+                </Button>
+              </Link>
+              <Link href="/vendors">
+                <Button variant="ghost" className="w-full text-sm text-muted-foreground">
+                  Browse vendors without signing in
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Phone, Lock, User, Loader2, ShoppingBag, Store, Truck } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useAuth } from '@/hooks/use-auth';
+import { DEMO_MODE } from '@/lib/config/demo';
+import type { UserRole } from '@/types';
+
+const roleOptions = [
+  {
+    value: 'customer' as UserRole,
+    label: 'Customer',
+    description: 'Order food from local vendors',
+    icon: ShoppingBag,
+    color: 'border-green-500 bg-green-50 dark:bg-green-950',
+    selectedColor: 'border-green-500 ring-2 ring-green-500',
+  },
+  {
+    value: 'vendor' as UserRole,
+    label: 'Vendor',
+    description: 'Sell food to the community',
+    icon: Store,
+    color: 'border-amber-500 bg-amber-50 dark:bg-amber-950',
+    selectedColor: 'border-amber-500 ring-2 ring-amber-500',
+  },
+  {
+    value: 'delivery' as UserRole,
+    label: 'Delivery',
+    description: 'Deliver orders in your area',
+    icon: Truck,
+    color: 'border-blue-500 bg-blue-50 dark:bg-blue-950',
+    selectedColor: 'border-blue-500 ring-2 ring-blue-500',
+  },
+];
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const { signUp } = useAuth();
+  const [name, setName] = useState('');
+  const [phone, setPhone] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState<UserRole>('customer');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Demo mode doesn't need registration
+  if (DEMO_MODE) {
+    router.push('/');
+    return null;
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !phone.trim() || !password) return;
+
+    if (password.length < 6) {
+      setError('Password must be at least 6 characters');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    const { error: signUpError } = await signUp(phone.trim(), password, name.trim(), role);
+
+    if (signUpError) {
+      setError(signUpError);
+      setLoading(false);
+    } else {
+      router.push('/');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center px-4 py-8">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">Create Account</CardTitle>
+          <CardDescription>Join the Firefly community</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium flex items-center gap-2">
+                <User className="w-4 h-4" />
+                Full Name
+              </label>
+              <Input
+                type="text"
+                placeholder="Your name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="h-12"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium flex items-center gap-2">
+                <Phone className="w-4 h-4" />
+                Phone Number
+              </label>
+              <Input
+                type="tel"
+                placeholder="+1 555 000 0000"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                className="h-12"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium flex items-center gap-2">
+                <Lock className="w-4 h-4" />
+                Password
+              </label>
+              <Input
+                type="password"
+                placeholder="At least 6 characters"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="h-12"
+                minLength={6}
+                required
+              />
+            </div>
+
+            {/* Role Selection */}
+            <div className="space-y-2">
+              <label className="text-sm font-medium">I want to...</label>
+              <div className="grid grid-cols-3 gap-2">
+                {roleOptions.map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => setRole(opt.value)}
+                    className={`p-3 rounded-lg border-2 text-center transition-all ${
+                      role === opt.value ? opt.selectedColor : opt.color
+                    }`}
+                  >
+                    <opt.icon className="w-5 h-5 mx-auto mb-1" />
+                    <span className="text-xs font-medium block">{opt.label}</span>
+                  </button>
+                ))}
+              </div>
+              <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
+                {roleOptions.find((o) => o.value === role)?.description}
+              </p>
+            </div>
+
+            {error && (
+              <div className="p-3 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-lg text-sm text-center">
+                {error}
+              </div>
+            )}
+
+            <Button
+              type="submit"
+              className="w-full bg-green-600 hover:bg-green-700 h-12 text-base"
+              disabled={loading}
+            >
+              {loading ? (
+                <>
+                  <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+                  Creating account...
+                </>
+              ) : (
+                'Create Account'
+              )}
+            </Button>
+          </form>
+
+          <p className="text-center text-sm text-gray-500 dark:text-gray-400 mt-6">
+            Already have an account?{' '}
+            <Link
+              href="/login"
+              className="text-green-600 hover:text-green-700 font-medium"
+            >
+              Sign in
+            </Link>
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/vendor/page.tsx
+++ b/src/app/vendor/page.tsx
@@ -8,7 +8,7 @@ import { Separator } from '@/components/ui/separator';
 import { OrderStatusBadge } from '@/components/order-status';
 import { useVendorOrders, updateOrderStatus, vendorAcceptOrder } from '@/hooks/use-orders';
 import type { OrderWithDetails, DeliveryAssignment } from '@/lib/supabase/types';
-import { DEMO_IDS } from '@/lib/config/demo';
+import { useAuth } from '@/hooks/use-auth';
 
 // Extended order type with delivery assignment and vendor_accepted
 interface VendorOrder extends OrderWithDetails {
@@ -17,7 +17,8 @@ interface VendorOrder extends OrderWithDetails {
 }
 
 export default function VendorDashboard() {
-  const { orders, loading, error } = useVendorOrders(DEMO_IDS.VENDOR_ID);
+  const { vendorId } = useAuth();
+  const { orders, loading, error } = useVendorOrders(vendorId!);
   const [updating, setUpdating] = useState<string | null>(null);
 
   const handleAcceptOrder = async (orderId: string) => {

--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  ReactNode,
+} from 'react';
+import { Session, User as SupabaseUser } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase/client';
+import { DEMO_MODE, DEMO_IDS } from '@/lib/config/demo';
+import { useRole } from '@/hooks/use-role';
+import type { UserRole } from '@/types';
+
+interface AuthContextType {
+  user: {
+    id: string;
+    phone: string;
+    name: string;
+    roles: UserRole[];
+    default_role?: UserRole;
+  } | null;
+  session: Session | null;
+  loading: boolean;
+  signIn: (phone: string, password: string) => Promise<{ error: string | null }>;
+  signUp: (
+    phone: string,
+    password: string,
+    name: string,
+    role: UserRole
+  ) => Promise<{ error: string | null }>;
+  signOut: () => Promise<void>;
+  userId: string | null;
+  vendorId: string | null;
+  deliveryPersonId: string | null;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+// Demo user mappings from seed.sql
+const DEMO_USERS = {
+  customer: {
+    id: '00000000-0000-0000-0000-000000000001',
+    phone: '555-0101',
+    name: 'Demo Customer',
+    roles: ['customer'] as UserRole[],
+    default_role: 'customer' as UserRole,
+  },
+  vendor: {
+    id: '00000000-0000-0000-0000-000000000002',
+    phone: '555-0102',
+    name: 'Maria Garcia',
+    roles: ['vendor'] as UserRole[],
+    default_role: 'vendor' as UserRole,
+  },
+  delivery: {
+    id: '00000000-0000-0000-0000-000000000003',
+    phone: '555-0103',
+    name: 'Alex Johnson',
+    roles: ['delivery'] as UserRole[],
+    default_role: 'delivery' as UserRole,
+  },
+};
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const { currentRole } = useRole();
+
+  if (DEMO_MODE) {
+    return (
+      <DemoAuthProvider currentRole={currentRole}>
+        {children}
+      </DemoAuthProvider>
+    );
+  }
+
+  return <ProductionAuthProvider>{children}</ProductionAuthProvider>;
+}
+
+function DemoAuthProvider({
+  children,
+  currentRole,
+}: {
+  children: ReactNode;
+  currentRole: UserRole;
+}) {
+  const value = useMemo<AuthContextType>(() => {
+    const demoUser = DEMO_USERS[currentRole];
+    return {
+      user: demoUser,
+      session: null,
+      loading: false,
+      signIn: async () => ({ error: null }),
+      signUp: async () => ({ error: null }),
+      signOut: async () => {},
+      userId: demoUser.id,
+      vendorId: DEMO_IDS.VENDOR_ID,
+      deliveryPersonId: DEMO_IDS.DELIVERY_PERSON_ID,
+    };
+  }, [currentRole]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+function ProductionAuthProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null);
+  const [user, setUser] = useState<AuthContextType['user']>(null);
+  const [vendorId, setVendorId] = useState<string | null>(null);
+  const [deliveryPersonId, setDeliveryPersonId] = useState<string | null>(null);
+  const supabase = useMemo(() => {
+    if (typeof window === 'undefined') return null;
+    return createClient();
+  }, []);
+
+  const [loading, setLoading] = useState(!!supabase);
+
+  const fetchUserProfile = useCallback(
+    async (authUser: SupabaseUser) => {
+      if (!supabase) return;
+      // Fetch public.users record
+      const { data: profile } = await supabase
+        .from('users')
+        .select('*')
+        .eq('id', authUser.id)
+        .single();
+
+      if (profile) {
+        setUser({
+          id: profile.id,
+          phone: profile.phone || authUser.phone || '',
+          name: profile.name,
+          roles: profile.roles || ['customer'],
+          default_role: profile.default_role,
+        });
+
+        // Fetch vendor record if user has vendor role
+        if (profile.roles?.includes('vendor')) {
+          const { data: vendor } = await supabase
+            .from('vendors')
+            .select('id')
+            .eq('user_id', profile.id)
+            .single();
+          setVendorId(vendor?.id || null);
+        }
+
+        // Fetch delivery person record if user has delivery role
+        if (profile.roles?.includes('delivery')) {
+          const { data: dp } = await supabase
+            .from('delivery_persons')
+            .select('id')
+            .eq('user_id', profile.id)
+            .single();
+          setDeliveryPersonId(dp?.id || null);
+        }
+      }
+    },
+    [supabase]
+  );
+
+  useEffect(() => {
+    if (!supabase) return;
+
+    // Get initial session
+    supabase.auth.getSession().then(({ data: { session: s } }) => {
+      setSession(s);
+      if (s?.user) {
+        fetchUserProfile(s.user).finally(() => setLoading(false));
+      } else {
+        setLoading(false);
+      }
+    });
+
+    // Listen for auth changes
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, s) => {
+      setSession(s);
+      if (s?.user) {
+        fetchUserProfile(s.user);
+      } else {
+        setUser(null);
+        setVendorId(null);
+        setDeliveryPersonId(null);
+      }
+    });
+
+    return () => subscription.unsubscribe();
+  }, [supabase, fetchUserProfile]);
+
+  const signIn = useCallback(
+    async (phone: string, password: string) => {
+      if (!supabase) return { error: 'Not initialized' };
+      const { error } = await supabase.auth.signInWithPassword({
+        phone,
+        password,
+      });
+      if (error) return { error: error.message };
+      return { error: null };
+    },
+    [supabase]
+  );
+
+  const signUp = useCallback(
+    async (phone: string, password: string, name: string, role: UserRole) => {
+      if (!supabase) return { error: 'Not initialized' };
+      const { data, error } = await supabase.auth.signUp({
+        phone,
+        password,
+      });
+      if (error) return { error: error.message };
+      if (!data.user) return { error: 'Sign up failed' };
+
+      // Create public.users record
+      const { error: profileError } = await supabase.from('users').insert({
+        id: data.user.id,
+        email: '',
+        name,
+        phone,
+        roles: [role],
+        default_role: role,
+      });
+
+      if (profileError) {
+        return { error: 'Account created but profile setup failed. Please contact support.' };
+      }
+
+      // Create role-specific records
+      if (role === 'vendor') {
+        await supabase.from('vendors').insert({
+          user_id: data.user.id,
+          name: `${name}'s Kitchen`,
+          is_active: true,
+        });
+      } else if (role === 'delivery') {
+        await supabase.from('delivery_persons').insert({
+          user_id: data.user.id,
+          is_active: true,
+          is_available: true,
+          vehicle_type: 'bike',
+        });
+      }
+
+      return { error: null };
+    },
+    [supabase]
+  );
+
+  const signOut = useCallback(async () => {
+    if (!supabase) return;
+    await supabase.auth.signOut();
+    setUser(null);
+    setVendorId(null);
+    setDeliveryPersonId(null);
+  }, [supabase]);
+
+  const value = useMemo<AuthContextType>(
+    () => ({
+      user,
+      session,
+      loading,
+      signIn,
+      signUp,
+      signOut,
+      userId: user?.id || null,
+      vendorId,
+      deliveryPersonId,
+    }),
+    [user, session, loading, signIn, signUp, signOut, vendorId, deliveryPersonId]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/src/lib/auth/guard.ts
+++ b/src/lib/auth/guard.ts
@@ -1,0 +1,32 @@
+import { createClient } from '@/lib/supabase/server';
+import { DEMO_MODE } from '@/lib/config/demo';
+import { NextResponse } from 'next/server';
+import type { User } from '@supabase/supabase-js';
+
+interface AuthResult {
+  user: User | null;
+  error: string | null;
+  isDemoMode: boolean;
+}
+
+export async function getAuthenticatedUser(): Promise<AuthResult> {
+  if (DEMO_MODE) {
+    return { user: null, error: null, isDemoMode: true };
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return { user: null, error: 'Unauthorized', isDemoMode: false };
+  }
+
+  return { user, error: null, isDemoMode: false };
+}
+
+export function unauthorizedResponse() {
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,70 @@
+import { createServerClient } from '@supabase/ssr';
+import { NextResponse, type NextRequest } from 'next/server';
+
+const publicRoutes = ['/', '/login', '/register', '/vendors'];
+
+function isPublicRoute(pathname: string): boolean {
+  if (publicRoutes.includes(pathname)) return true;
+  // /vendors/[id] is also public (browsing)
+  if (pathname.startsWith('/vendors/')) return true;
+  return false;
+}
+
+export async function middleware(request: NextRequest) {
+  // Demo mode: pass-through
+  if (process.env.NEXT_PUBLIC_DEMO_MODE === 'true') {
+    return NextResponse.next();
+  }
+
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value)
+          );
+          supabaseResponse = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options)
+          );
+        },
+      },
+    }
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { pathname } = request.nextUrl;
+
+  // Redirect unauthenticated users from protected routes to login
+  if (!user && !isPublicRoute(pathname)) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/login';
+    url.searchParams.set('redirect', pathname);
+    return NextResponse.redirect(url);
+  }
+
+  // Redirect authenticated users away from login/register
+  if (user && (pathname === '/login' || pathname === '/register')) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/';
+    return NextResponse.redirect(url);
+  }
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|manifest.json|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+};


### PR DESCRIPTION
## Summary
- Add Supabase authentication that activates when `DEMO_MODE=false`, preserving existing demo functionality
- Implement phone number + password auth (login/register pages) with role selection on signup
- Add `AuthProvider` context that abstracts demo vs production user identity across all pages
- Protect routes via Next.js middleware (redirects unauthenticated users to `/login`)
- Guard all API routes with server-side auth validation; override client-sent `customer_id` with authenticated user ID in production

## New files
- `src/hooks/use-auth.tsx` — Auth context provider with demo/production branching
- `src/middleware.ts` — Route protection middleware
- `src/app/login/page.tsx` — Phone + password login page
- `src/app/register/page.tsx` — Registration with role selection (customer/vendor/delivery)
- `src/lib/auth/guard.ts` — Shared server-side auth guard for API routes

## Modified files
- `src/app/layout.tsx` — Wrap with `AuthProvider`
- `src/app/page.tsx` — Show sign-in/register landing in production mode
- `src/app/checkout/page.tsx` — Use `useAuth().userId` instead of `DEMO_IDS`
- `src/app/vendor/page.tsx` — Use `useAuth().vendorId` instead of `DEMO_IDS`
- `src/app/delivery/page.tsx` — Use `useAuth().deliveryPersonId` instead of `DEMO_IDS`
- All 4 API routes — Add `getAuthenticatedUser()` guard

## Test plan
- [ ] Verify `DEMO_MODE=true` works exactly as before (role cards, hardcoded IDs, no login)
- [ ] Verify `DEMO_MODE=false` shows sign-in/register landing page
- [ ] Verify protected routes redirect to `/login` when unauthenticated
- [ ] Verify `/vendors` browsing works without auth
- [ ] Verify API routes return 401 for unauthenticated requests in production mode
- [ ] Verify `npm run build` passes
- [ ] Verify `npm run lint` passes on changed files

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)