### PR TITLE
Fix middleware redirecting API routes to login page

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,6 +7,8 @@ function isPublicRoute(pathname: string): boolean {
   if (publicRoutes.includes(pathname)) return true;
   // /vendors/[id] is also public (browsing)
   if (pathname.startsWith('/vendors/')) return true;
+  // API routes handle their own auth via guard.ts
+  if (pathname.startsWith('/api/')) return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary
- API routes (`/api/*`) were being caught by the middleware's auth redirect, sending unauthenticated requests to `/login` instead of letting them reach their route handlers
- API routes already have their own auth guards via `guard.ts` that return proper `401 {"error":"Unauthorized"}` JSON responses
- Added `/api/` prefix check to `isPublicRoute()` so middleware passes API requests through to their own handlers

## Test plan
- [ ] `DEMO_MODE=false`: `curl http://localhost:3000/api/orders` returns `401 {"error":"Unauthorized"}` (not a redirect)
- [ ] `DEMO_MODE=false`: `curl http://localhost:3000/vendor` redirects to `/login` (page routes still protected)
- [ ] `DEMO_MODE=true`: All routes accessible without auth (no regression)
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)