### PR TITLE
Switch auth to email and fix authenticated home page

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,18 +3,21 @@
 import { Suspense, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { Phone, Lock, Loader2 } from 'lucide-react';
+import { Mail, Phone, Lock, Loader2 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useAuth } from '@/hooks/use-auth';
 import { DEMO_MODE } from '@/lib/config/demo';
 
+type AuthMethod = 'email' | 'phone';
+
 function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { signIn } = useAuth();
-  const [phone, setPhone] = useState('');
+  const [method, setMethod] = useState<AuthMethod>('email');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -27,12 +30,12 @@ function LoginForm() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!phone.trim() || !password) return;
+    if (!email.trim() || !password) return;
 
     setLoading(true);
     setError(null);
 
-    const { error: signInError } = await signIn(phone.trim(), password);
+    const { error: signInError } = await signIn(email.trim(), password);
 
     if (signInError) {
       setError(signInError);
@@ -53,58 +56,98 @@ function LoginForm() {
           </p>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <label className="text-sm font-medium flex items-center gap-2">
-                <Phone className="w-4 h-4" />
-                Phone Number
-              </label>
-              <Input
-                type="tel"
-                placeholder="+1 555 000 0000"
-                value={phone}
-                onChange={(e) => setPhone(e.target.value)}
-                className="h-12"
-                required
-              />
-            </div>
-
-            <div className="space-y-2">
-              <label className="text-sm font-medium flex items-center gap-2">
-                <Lock className="w-4 h-4" />
-                Password
-              </label>
-              <Input
-                type="password"
-                placeholder="Enter your password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="h-12"
-                required
-              />
-            </div>
-
-            {error && (
-              <div className="p-3 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-lg text-sm text-center">
-                {error}
-              </div>
-            )}
-
-            <Button
-              type="submit"
-              className="w-full bg-green-600 hover:bg-green-700 h-12 text-base"
-              disabled={loading}
+          {/* Method Tabs */}
+          <div className="flex rounded-lg border border-gray-200 dark:border-gray-700 mb-6">
+            <button
+              type="button"
+              onClick={() => { setMethod('email'); setError(null); }}
+              className={`flex-1 flex items-center justify-center gap-2 py-2.5 text-sm font-medium rounded-l-lg transition-colors ${
+                method === 'email'
+                  ? 'bg-green-600 text-white'
+                  : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+              }`}
             >
-              {loading ? (
-                <>
-                  <Loader2 className="w-5 h-5 mr-2 animate-spin" />
-                  Signing in...
-                </>
-              ) : (
-                'Sign In'
+              <Mail className="w-4 h-4" />
+              Email
+            </button>
+            <button
+              type="button"
+              onClick={() => { setMethod('phone'); setError(null); }}
+              className={`flex-1 flex items-center justify-center gap-2 py-2.5 text-sm font-medium rounded-r-lg transition-colors ${
+                method === 'phone'
+                  ? 'bg-green-600 text-white'
+                  : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+              }`}
+            >
+              <Phone className="w-4 h-4" />
+              Phone
+            </button>
+          </div>
+
+          {method === 'phone' ? (
+            <div className="text-center py-8">
+              <Phone className="w-10 h-10 mx-auto mb-3 text-gray-400" />
+              <p className="text-gray-600 dark:text-gray-400 font-medium">
+                Phone login coming soon
+              </p>
+              <p className="text-sm text-gray-400 dark:text-gray-500 mt-1">
+                Use email to sign in for now
+              </p>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium flex items-center gap-2">
+                  <Mail className="w-4 h-4" />
+                  Email
+                </label>
+                <Input
+                  type="email"
+                  placeholder="you@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="h-12"
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium flex items-center gap-2">
+                  <Lock className="w-4 h-4" />
+                  Password
+                </label>
+                <Input
+                  type="password"
+                  placeholder="Enter your password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="h-12"
+                  required
+                />
+              </div>
+
+              {error && (
+                <div className="p-3 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-lg text-sm text-center">
+                  {error}
+                </div>
               )}
-            </Button>
-          </form>
+
+              <Button
+                type="submit"
+                className="w-full bg-green-600 hover:bg-green-700 h-12 text-base"
+                disabled={loading}
+              >
+                {loading ? (
+                  <>
+                    <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+                    Signing in...
+                  </>
+                ) : (
+                  'Sign In'
+                )}
+              </Button>
+            </form>
+          )}
 
           <p className="text-center text-sm text-gray-500 dark:text-gray-400 mt-6">
             Don&apos;t have an account?{' '}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,11 @@
+'use client';
+
 import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { ShoppingBag, Store, Truck } from "lucide-react";
+import { ShoppingBag, Store, Truck, LogOut } from "lucide-react";
 import { DEMO_MODE } from "@/lib/config/demo";
+import { useAuth } from "@/hooks/use-auth";
 
 const roles = [
   {
@@ -35,7 +38,63 @@ const roles = [
 ];
 
 export default function Home() {
+  const { user, loading, signOut } = useAuth();
+
   if (!DEMO_MODE) {
+    // Authenticated user: show role-based navigation
+    if (user && !loading) {
+      return (
+        <div className="min-h-screen bg-background">
+          <header className="border-b bg-background">
+            <div className="container flex h-16 items-center justify-between px-4">
+              <h1 className="text-2xl font-bold">Project Firefly</h1>
+              <div className="flex items-center gap-3">
+                <span className="text-sm text-muted-foreground">{user.name}</span>
+                <Button variant="ghost" size="sm" onClick={signOut}>
+                  <LogOut className="h-4 w-4 mr-1" />
+                  Sign Out
+                </Button>
+              </div>
+            </div>
+          </header>
+
+          <main className="container px-4 py-8">
+            <div className="mx-auto max-w-3xl space-y-8">
+              <div className="text-center space-y-2">
+                <p className="text-lg text-muted-foreground">
+                  Welcome back, {user.name}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  Select a role to continue
+                </p>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-3">
+                {roles.map((role) => (
+                  <Link key={role.name} href={role.href}>
+                    <Card className={`h-full transition-colors border-2 ${role.borderColor} ${role.hoverBg} cursor-pointer`}>
+                      <CardHeader className="text-center pb-2">
+                        <div className={`mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full ${role.color} text-white`}>
+                          <role.icon className="h-6 w-6" />
+                        </div>
+                        <CardTitle className="text-lg">{role.name}</CardTitle>
+                      </CardHeader>
+                      <CardContent>
+                        <CardDescription className="text-center">
+                          {role.description}
+                        </CardDescription>
+                      </CardContent>
+                    </Card>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          </main>
+        </div>
+      );
+    }
+
+    // Not authenticated: show sign-in / create account
     return (
       <div className="min-h-screen bg-background">
         <header className="border-b bg-background">

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -3,13 +3,15 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { Phone, Lock, User, Loader2, ShoppingBag, Store, Truck } from 'lucide-react';
+import { Mail, Phone, Lock, User, Loader2, ShoppingBag, Store, Truck } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useAuth } from '@/hooks/use-auth';
 import { DEMO_MODE } from '@/lib/config/demo';
 import type { UserRole } from '@/types';
+
+type AuthMethod = 'email' | 'phone';
 
 const roleOptions = [
   {
@@ -41,8 +43,9 @@ const roleOptions = [
 export default function RegisterPage() {
   const router = useRouter();
   const { signUp } = useAuth();
+  const [method, setMethod] = useState<AuthMethod>('email');
   const [name, setName] = useState('');
-  const [phone, setPhone] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [role, setRole] = useState<UserRole>('customer');
   const [error, setError] = useState<string | null>(null);
@@ -56,7 +59,7 @@ export default function RegisterPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!name.trim() || !phone.trim() || !password) return;
+    if (!name.trim() || !email.trim() || !password) return;
 
     if (password.length < 6) {
       setError('Password must be at least 6 characters');
@@ -66,7 +69,7 @@ export default function RegisterPage() {
     setLoading(true);
     setError(null);
 
-    const { error: signUpError } = await signUp(phone.trim(), password, name.trim(), role);
+    const { error: signUpError } = await signUp(email.trim(), password, name.trim(), role);
 
     if (signUpError) {
       setError(signUpError);
@@ -84,97 +87,137 @@ export default function RegisterPage() {
           <CardDescription>Join the Firefly community</CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <label className="text-sm font-medium flex items-center gap-2">
-                <User className="w-4 h-4" />
-                Full Name
-              </label>
-              <Input
-                type="text"
-                placeholder="Your name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                className="h-12"
-                required
-              />
-            </div>
+          {/* Method Tabs */}
+          <div className="flex rounded-lg border border-gray-200 dark:border-gray-700 mb-6">
+            <button
+              type="button"
+              onClick={() => { setMethod('email'); setError(null); }}
+              className={`flex-1 flex items-center justify-center gap-2 py-2.5 text-sm font-medium rounded-l-lg transition-colors ${
+                method === 'email'
+                  ? 'bg-green-600 text-white'
+                  : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+              }`}
+            >
+              <Mail className="w-4 h-4" />
+              Email
+            </button>
+            <button
+              type="button"
+              onClick={() => { setMethod('phone'); setError(null); }}
+              className={`flex-1 flex items-center justify-center gap-2 py-2.5 text-sm font-medium rounded-r-lg transition-colors ${
+                method === 'phone'
+                  ? 'bg-green-600 text-white'
+                  : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'
+              }`}
+            >
+              <Phone className="w-4 h-4" />
+              Phone
+            </button>
+          </div>
 
-            <div className="space-y-2">
-              <label className="text-sm font-medium flex items-center gap-2">
-                <Phone className="w-4 h-4" />
-                Phone Number
-              </label>
-              <Input
-                type="tel"
-                placeholder="+1 555 000 0000"
-                value={phone}
-                onChange={(e) => setPhone(e.target.value)}
-                className="h-12"
-                required
-              />
-            </div>
-
-            <div className="space-y-2">
-              <label className="text-sm font-medium flex items-center gap-2">
-                <Lock className="w-4 h-4" />
-                Password
-              </label>
-              <Input
-                type="password"
-                placeholder="At least 6 characters"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="h-12"
-                minLength={6}
-                required
-              />
-            </div>
-
-            {/* Role Selection */}
-            <div className="space-y-2">
-              <label className="text-sm font-medium">I want to...</label>
-              <div className="grid grid-cols-3 gap-2">
-                {roleOptions.map((opt) => (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    onClick={() => setRole(opt.value)}
-                    className={`p-3 rounded-lg border-2 text-center transition-all ${
-                      role === opt.value ? opt.selectedColor : opt.color
-                    }`}
-                  >
-                    <opt.icon className="w-5 h-5 mx-auto mb-1" />
-                    <span className="text-xs font-medium block">{opt.label}</span>
-                  </button>
-                ))}
-              </div>
-              <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
-                {roleOptions.find((o) => o.value === role)?.description}
+          {method === 'phone' ? (
+            <div className="text-center py-8">
+              <Phone className="w-10 h-10 mx-auto mb-3 text-gray-400" />
+              <p className="text-gray-600 dark:text-gray-400 font-medium">
+                Phone registration coming soon
+              </p>
+              <p className="text-sm text-gray-400 dark:text-gray-500 mt-1">
+                Use email to create your account for now
               </p>
             </div>
-
-            {error && (
-              <div className="p-3 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-lg text-sm text-center">
-                {error}
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium flex items-center gap-2">
+                  <User className="w-4 h-4" />
+                  Full Name
+                </label>
+                <Input
+                  type="text"
+                  placeholder="Your name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  className="h-12"
+                  required
+                />
               </div>
-            )}
 
-            <Button
-              type="submit"
-              className="w-full bg-green-600 hover:bg-green-700 h-12 text-base"
-              disabled={loading}
-            >
-              {loading ? (
-                <>
-                  <Loader2 className="w-5 h-5 mr-2 animate-spin" />
-                  Creating account...
-                </>
-              ) : (
-                'Create Account'
+              <div className="space-y-2">
+                <label className="text-sm font-medium flex items-center gap-2">
+                  <Mail className="w-4 h-4" />
+                  Email
+                </label>
+                <Input
+                  type="email"
+                  placeholder="you@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="h-12"
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-sm font-medium flex items-center gap-2">
+                  <Lock className="w-4 h-4" />
+                  Password
+                </label>
+                <Input
+                  type="password"
+                  placeholder="At least 6 characters"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="h-12"
+                  minLength={6}
+                  required
+                />
+              </div>
+
+              {/* Role Selection */}
+              <div className="space-y-2">
+                <label className="text-sm font-medium">I want to...</label>
+                <div className="grid grid-cols-3 gap-2">
+                  {roleOptions.map((opt) => (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => setRole(opt.value)}
+                      className={`p-3 rounded-lg border-2 text-center transition-all ${
+                        role === opt.value ? opt.selectedColor : opt.color
+                      }`}
+                    >
+                      <opt.icon className="w-5 h-5 mx-auto mb-1" />
+                      <span className="text-xs font-medium block">{opt.label}</span>
+                    </button>
+                  ))}
+                </div>
+                <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
+                  {roleOptions.find((o) => o.value === role)?.description}
+                </p>
+              </div>
+
+              {error && (
+                <div className="p-3 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-lg text-sm text-center">
+                  {error}
+                </div>
               )}
-            </Button>
-          </form>
+
+              <Button
+                type="submit"
+                className="w-full bg-green-600 hover:bg-green-700 h-12 text-base"
+                disabled={loading}
+              >
+                {loading ? (
+                  <>
+                    <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+                    Creating account...
+                  </>
+                ) : (
+                  'Create Account'
+                )}
+              </Button>
+            </form>
+          )}
 
           <p className="text-center text-sm text-gray-500 dark:text-gray-400 mt-6">
             Already have an account?{' '}

--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -18,16 +18,16 @@ import type { UserRole } from '@/types';
 interface AuthContextType {
   user: {
     id: string;
-    phone: string;
+    email: string;
     name: string;
     roles: UserRole[];
     default_role?: UserRole;
   } | null;
   session: Session | null;
   loading: boolean;
-  signIn: (phone: string, password: string) => Promise<{ error: string | null }>;
+  signIn: (email: string, password: string) => Promise<{ error: string | null }>;
   signUp: (
-    phone: string,
+    email: string,
     password: string,
     name: string,
     role: UserRole
@@ -44,21 +44,21 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 const DEMO_USERS = {
   customer: {
     id: '00000000-0000-0000-0000-000000000001',
-    phone: '555-0101',
+    email: 'customer@demo.firefly',
     name: 'Demo Customer',
     roles: ['customer'] as UserRole[],
     default_role: 'customer' as UserRole,
   },
   vendor: {
     id: '00000000-0000-0000-0000-000000000002',
-    phone: '555-0102',
+    email: 'maria@demo.firefly',
     name: 'Maria Garcia',
     roles: ['vendor'] as UserRole[],
     default_role: 'vendor' as UserRole,
   },
   delivery: {
     id: '00000000-0000-0000-0000-000000000003',
-    phone: '555-0103',
+    email: 'alex@demo.firefly',
     name: 'Alex Johnson',
     roles: ['delivery'] as UserRole[],
     default_role: 'delivery' as UserRole,
@@ -129,7 +129,7 @@ function ProductionAuthProvider({ children }: { children: ReactNode }) {
       if (profile) {
         setUser({
           id: profile.id,
-          phone: profile.phone || authUser.phone || '',
+          email: profile.email || authUser.email || '',
           name: profile.name,
           roles: profile.roles || ['customer'],
           default_role: profile.default_role,
@@ -190,10 +190,10 @@ function ProductionAuthProvider({ children }: { children: ReactNode }) {
   }, [supabase, fetchUserProfile]);
 
   const signIn = useCallback(
-    async (phone: string, password: string) => {
+    async (email: string, password: string) => {
       if (!supabase) return { error: 'Not initialized' };
       const { error } = await supabase.auth.signInWithPassword({
-        phone,
+        email,
         password,
       });
       if (error) return { error: error.message };
@@ -203,10 +203,10 @@ function ProductionAuthProvider({ children }: { children: ReactNode }) {
   );
 
   const signUp = useCallback(
-    async (phone: string, password: string, name: string, role: UserRole) => {
+    async (email: string, password: string, name: string, role: UserRole) => {
       if (!supabase) return { error: 'Not initialized' };
       const { data, error } = await supabase.auth.signUp({
-        phone,
+        email,
         password,
       });
       if (error) return { error: error.message };
@@ -215,9 +215,9 @@ function ProductionAuthProvider({ children }: { children: ReactNode }) {
       // Create public.users record
       const { error: profileError } = await supabase.from('users').insert({
         id: data.user.id,
-        email: '',
+        email,
         name,
-        phone,
+        phone: '',
         roles: [role],
         default_role: role,
       });


### PR DESCRIPTION
## Summary
- Switched authentication from phone-based to email-based (phone auth required Supabase provider setup)
- Login and register pages now have Email/Phone tab switcher; phone tab shows "coming soon"
- Home page shows role cards (Customer, Vendor, Delivery) with sign out when authenticated, and sign-in/create account when not
- Auth hook updated: `signIn`/`signUp` use email, user interface uses `email` field instead of `phone`

## Test plan
- [ ] Register with email + password — account created successfully
- [ ] Login with email + password — redirected to home with role cards
- [ ] Click Phone tab on login/register — shows "coming soon" message
- [ ] Authenticated home page shows all 3 role cards + sign out button
- [ ] Sign out returns to unauthenticated view with Sign In / Create Account
- [ ] Demo mode (`DEMO_MODE=true`) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)