### PR TITLE
Add persistent header with role switcher and lazy provisioning

### DIFF
--- a/src/app/delivery/page.tsx
+++ b/src/app/delivery/page.tsx
@@ -17,8 +17,19 @@ interface DeliveryOrder extends OrderWithDetails {
 
 export default function DeliveryDashboard() {
   const { deliveryPersonId } = useAuth();
-  const { assignments, loading, error } = useDeliveryAssignments(deliveryPersonId!);
+  const { assignments, loading, error } = useDeliveryAssignments(deliveryPersonId ?? '');
   const [updating, setUpdating] = useState<string | null>(null);
+
+  if (!deliveryPersonId) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-gray-500 dark:text-gray-400">Setting up delivery account...</p>
+        </div>
+      </div>
+    );
+  }
 
   const handleStatusUpdate = async (
     assignmentId: string,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { RoleProvider } from "@/hooks/use-role";
 import { AuthProvider } from "@/hooks/use-auth";
 import { CartProvider } from "@/hooks/use-cart";
+import { AppHeader } from "@/components/shared/app-header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -38,13 +39,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {process.env.NEXT_PUBLIC_DEMO_MODE === 'true' && (
-          <div className="bg-amber-500 text-white text-center text-xs py-1">
-            DEMO MODE
-          </div>
-        )}
         <RoleProvider>
           <AuthProvider>
+            <AppHeader />
             <CartProvider>
               {children}
             </CartProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,19 @@
 'use client';
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { ShoppingBag, Store, Truck, LogOut } from "lucide-react";
+import { ShoppingBag, Store, Truck } from "lucide-react";
 import { DEMO_MODE } from "@/lib/config/demo";
 import { useAuth } from "@/hooks/use-auth";
+import { useRole } from "@/hooks/use-role";
+import type { UserRole } from "@/types";
 
 const roles = [
   {
     name: "Customer",
+    role: "customer" as UserRole,
     description: "Browse local vendors, add items to your cart, and place orders for delivery.",
     href: "/vendors",
     icon: ShoppingBag,
@@ -19,6 +23,7 @@ const roles = [
   },
   {
     name: "Vendor",
+    role: "vendor" as UserRole,
     description: "View incoming orders, update order status, and communicate with customers.",
     href: "/vendor",
     icon: Store,
@@ -28,6 +33,7 @@ const roles = [
   },
   {
     name: "Delivery",
+    role: "delivery" as UserRole,
     description: "Accept delivery requests, navigate to pickups, and complete deliveries.",
     href: "/delivery",
     icon: Truck,
@@ -38,178 +44,150 @@ const roles = [
 ];
 
 export default function Home() {
-  const { user, loading, signOut } = useAuth();
+  const { user, loading } = useAuth();
+  const { setRole } = useRole();
+  const router = useRouter();
+
+  const handleRoleClick = (role: UserRole, href: string) => {
+    setRole(role);
+    router.push(href);
+  };
 
   if (!DEMO_MODE) {
     // Authenticated user: show role-based navigation
     if (user && !loading) {
       return (
-        <div className="min-h-screen bg-background">
-          <header className="border-b bg-background">
-            <div className="container flex h-16 items-center justify-between px-4">
-              <h1 className="text-2xl font-bold">Project Firefly</h1>
-              <div className="flex items-center gap-3">
-                <span className="text-sm text-muted-foreground">{user.name}</span>
-                <Button variant="ghost" size="sm" onClick={signOut}>
-                  <LogOut className="h-4 w-4 mr-1" />
-                  Sign Out
-                </Button>
-              </div>
+        <main className="container px-4 py-8">
+          <div className="mx-auto max-w-3xl space-y-8">
+            <div className="text-center space-y-2">
+              <p className="text-lg text-muted-foreground">
+                Welcome back, {user.name}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Select a role to continue
+              </p>
             </div>
-          </header>
 
-          <main className="container px-4 py-8">
-            <div className="mx-auto max-w-3xl space-y-8">
-              <div className="text-center space-y-2">
-                <p className="text-lg text-muted-foreground">
-                  Welcome back, {user.name}
-                </p>
-                <p className="text-sm text-muted-foreground">
-                  Select a role to continue
-                </p>
-              </div>
-
-              <div className="grid gap-4 md:grid-cols-3">
-                {roles.map((role) => (
-                  <Link key={role.name} href={role.href}>
-                    <Card className={`h-full transition-colors border-2 ${role.borderColor} ${role.hoverBg} cursor-pointer`}>
-                      <CardHeader className="text-center pb-2">
-                        <div className={`mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full ${role.color} text-white`}>
-                          <role.icon className="h-6 w-6" />
-                        </div>
-                        <CardTitle className="text-lg">{role.name}</CardTitle>
-                      </CardHeader>
-                      <CardContent>
-                        <CardDescription className="text-center">
-                          {role.description}
-                        </CardDescription>
-                      </CardContent>
-                    </Card>
-                  </Link>
-                ))}
-              </div>
+            <div className="grid gap-4 md:grid-cols-3">
+              {roles.map((role) => (
+                <button key={role.name} onClick={() => handleRoleClick(role.role, role.href)} className="text-left">
+                  <Card className={`h-full transition-colors border-2 ${role.borderColor} ${role.hoverBg} cursor-pointer`}>
+                    <CardHeader className="text-center pb-2">
+                      <div className={`mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full ${role.color} text-white`}>
+                        <role.icon className="h-6 w-6" />
+                      </div>
+                      <CardTitle className="text-lg">{role.name}</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <CardDescription className="text-center">
+                        {role.description}
+                      </CardDescription>
+                    </CardContent>
+                  </Card>
+                </button>
+              ))}
             </div>
-          </main>
-        </div>
+          </div>
+        </main>
       );
     }
 
     // Not authenticated: show sign-in / create account
     return (
-      <div className="min-h-screen bg-background">
-        <header className="border-b bg-background">
-          <div className="container flex h-16 items-center justify-center px-4">
-            <h1 className="text-2xl font-bold">Project Firefly</h1>
-          </div>
-        </header>
-
-        <main className="container px-4 py-8">
-          <div className="mx-auto max-w-md space-y-8 text-center">
-            <div className="space-y-2">
-              <p className="text-lg text-muted-foreground">
-                Community-powered food ordering for local co-ops
-              </p>
-              <p className="text-sm text-muted-foreground">
-                Order from local vendors, delivered by your neighbors
-              </p>
-            </div>
-
-            <div className="grid grid-cols-3 gap-4">
-              {roles.map((role) => (
-                <div key={role.name} className="text-center">
-                  <div className={`mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full ${role.color} text-white`}>
-                    <role.icon className="h-6 w-6" />
-                  </div>
-                  <p className="text-sm font-medium">{role.name}</p>
-                </div>
-              ))}
-            </div>
-
-            <div className="space-y-3">
-              <Link href="/login">
-                <Button className="w-full bg-green-600 hover:bg-green-700 h-12 text-base">
-                  Sign In
-                </Button>
-              </Link>
-              <Link href="/register">
-                <Button variant="outline" className="w-full h-12 text-base">
-                  Create Account
-                </Button>
-              </Link>
-              <Link href="/vendors">
-                <Button variant="ghost" className="w-full text-sm text-muted-foreground">
-                  Browse vendors without signing in
-                </Button>
-              </Link>
-            </div>
-          </div>
-        </main>
-      </div>
-    );
-  }
-
-  return (
-    <div className="min-h-screen bg-background">
-      {/* Header */}
-      <header className="border-b bg-background">
-        <div className="container flex h-16 items-center justify-center px-4">
-          <h1 className="text-2xl font-bold">Project Firefly Demo</h1>
-        </div>
-      </header>
-
-      {/* Main Content */}
       <main className="container px-4 py-8">
-        <div className="mx-auto max-w-3xl space-y-8">
-          {/* Description */}
-          <div className="text-center space-y-2">
+        <div className="mx-auto max-w-md space-y-8 text-center">
+          <div className="space-y-2">
             <p className="text-lg text-muted-foreground">
               Community-powered food ordering for local co-ops
             </p>
             <p className="text-sm text-muted-foreground">
-              Select a role below to explore the demo
+              Order from local vendors, delivered by your neighbors
             </p>
           </div>
 
-          {/* Role Cards */}
-          <div className="grid gap-4 md:grid-cols-3">
+          <div className="grid grid-cols-3 gap-4">
             {roles.map((role) => (
-              <Link key={role.name} href={role.href}>
-                <Card className={`h-full transition-colors border-2 ${role.borderColor} ${role.hoverBg} cursor-pointer`}>
-                  <CardHeader className="text-center pb-2">
-                    <div className={`mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full ${role.color} text-white`}>
-                      <role.icon className="h-6 w-6" />
-                    </div>
-                    <CardTitle className="text-lg">{role.name}</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <CardDescription className="text-center">
-                      {role.description}
-                    </CardDescription>
-                  </CardContent>
-                </Card>
-              </Link>
+              <div key={role.name} className="text-center">
+                <div className={`mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full ${role.color} text-white`}>
+                  <role.icon className="h-6 w-6" />
+                </div>
+                <p className="text-sm font-medium">{role.name}</p>
+              </div>
             ))}
           </div>
 
-          {/* Instructions */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">How to Test the Full Flow</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <ol className="list-decimal list-inside space-y-2 text-sm text-muted-foreground">
-                <li>Open <strong>3 browser tabs</strong> (or use incognito windows)</li>
-                <li>In Tab 1: Click <strong>Customer</strong> → Browse vendors and place an order</li>
-                <li>In Tab 2: Click <strong>Vendor</strong> → Watch for incoming orders and accept them</li>
-                <li>In Tab 3: Click <strong>Delivery</strong> → Accept the delivery and mark it complete</li>
-              </ol>
-              <p className="text-xs text-muted-foreground pt-2 border-t">
-                All roles see real-time updates via Supabase. Changes in one tab appear instantly in others.
-              </p>
-            </CardContent>
-          </Card>
+          <div className="space-y-3">
+            <Link href="/login">
+              <Button className="w-full bg-green-600 hover:bg-green-700 h-12 text-base">
+                Sign In
+              </Button>
+            </Link>
+            <Link href="/register">
+              <Button variant="outline" className="w-full h-12 text-base">
+                Create Account
+              </Button>
+            </Link>
+            <Link href="/vendors">
+              <Button variant="ghost" className="w-full text-sm text-muted-foreground">
+                Browse vendors without signing in
+              </Button>
+            </Link>
+          </div>
         </div>
       </main>
-    </div>
+    );
+  }
+
+  // Demo mode
+  return (
+    <main className="container px-4 py-8">
+      <div className="mx-auto max-w-3xl space-y-8">
+        <div className="text-center space-y-2">
+          <p className="text-lg text-muted-foreground">
+            Community-powered food ordering for local co-ops
+          </p>
+          <p className="text-sm text-muted-foreground">
+            Select a role below to explore the demo
+          </p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          {roles.map((role) => (
+            <button key={role.name} onClick={() => handleRoleClick(role.role, role.href)} className="text-left">
+              <Card className={`h-full transition-colors border-2 ${role.borderColor} ${role.hoverBg} cursor-pointer`}>
+                <CardHeader className="text-center pb-2">
+                  <div className={`mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full ${role.color} text-white`}>
+                    <role.icon className="h-6 w-6" />
+                  </div>
+                  <CardTitle className="text-lg">{role.name}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <CardDescription className="text-center">
+                    {role.description}
+                  </CardDescription>
+                </CardContent>
+              </Card>
+            </button>
+          ))}
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">How to Test the Full Flow</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <ol className="list-decimal list-inside space-y-2 text-sm text-muted-foreground">
+              <li>Open <strong>3 browser tabs</strong> (or use incognito windows)</li>
+              <li>In Tab 1: Click <strong>Customer</strong> → Browse vendors and place an order</li>
+              <li>In Tab 2: Click <strong>Vendor</strong> → Watch for incoming orders and accept them</li>
+              <li>In Tab 3: Click <strong>Delivery</strong> → Accept the delivery and mark it complete</li>
+            </ol>
+            <p className="text-xs text-muted-foreground pt-2 border-t">
+              All roles see real-time updates via Supabase. Changes in one tab appear instantly in others.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
   );
 }

--- a/src/app/vendor/page.tsx
+++ b/src/app/vendor/page.tsx
@@ -18,8 +18,19 @@ interface VendorOrder extends OrderWithDetails {
 
 export default function VendorDashboard() {
   const { vendorId } = useAuth();
-  const { orders, loading, error } = useVendorOrders(vendorId!);
+  const { orders, loading, error } = useVendorOrders(vendorId ?? '');
   const [updating, setUpdating] = useState<string | null>(null);
+
+  if (!vendorId) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-8 h-8 border-4 border-amber-500 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-gray-500 dark:text-gray-400">Setting up vendor account...</p>
+        </div>
+      </div>
+    );
+  }
 
   const handleAcceptOrder = async (orderId: string) => {
     setUpdating(orderId);

--- a/src/components/shared/app-header.tsx
+++ b/src/components/shared/app-header.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useAuth } from '@/hooks/use-auth';
+import { DEMO_MODE } from '@/lib/config/demo';
+import { RoleSwitcher } from '@/components/shared/role-switcher';
+import { Button } from '@/components/ui/button';
+import { LogOut } from 'lucide-react';
+
+export function AppHeader() {
+  const { user, loading, signOut } = useAuth();
+
+  const showRoleSwitcher = DEMO_MODE || (!loading && user);
+
+  return (
+    <header className="border-b bg-background">
+      <div className="container flex h-14 items-center justify-between px-4">
+        <div className="flex items-center gap-3">
+          <h1 className="text-xl font-bold">Project Firefly</h1>
+          {DEMO_MODE && (
+            <span className="bg-amber-500 text-white text-xs px-2 py-0.5 rounded font-medium">
+              DEMO
+            </span>
+          )}
+        </div>
+
+        {showRoleSwitcher && (
+          <div className="flex items-center gap-3">
+            {!DEMO_MODE && user && (
+              <>
+                <span className="text-sm text-muted-foreground hidden sm:inline">
+                  {user.name}
+                </span>
+                <Button variant="ghost" size="sm" onClick={signOut}>
+                  <LogOut className="h-4 w-4" />
+                </Button>
+              </>
+            )}
+            <RoleSwitcher
+              userInitials={user?.name?.charAt(0).toUpperCase() || 'U'}
+            />
+          </div>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/src/components/shared/role-switcher.tsx
+++ b/src/components/shared/role-switcher.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
   Sheet,
@@ -11,6 +12,12 @@ import {
 import { useRole } from '@/hooks/use-role';
 import type { UserRole } from '@/types';
 import { cn } from '@/lib/utils';
+
+const roleRoutes: Record<UserRole, string> = {
+  customer: '/vendors',
+  vendor: '/vendor',
+  delivery: '/delivery',
+};
 
 interface RoleSwitcherProps {
   userInitials?: string;
@@ -39,6 +46,12 @@ export function RoleSwitcher({
   availableRoles = ['customer', 'vendor', 'delivery'],
 }: RoleSwitcherProps) {
   const { currentRole, setRole, roleColor } = useRole();
+  const router = useRouter();
+
+  const handleRoleSwitch = (role: UserRole) => {
+    setRole(role);
+    router.push(roleRoutes[role]);
+  };
 
   return (
     <Sheet>
@@ -73,7 +86,7 @@ export function RoleSwitcher({
           {availableRoles.map((role) => (
             <button
               key={role}
-              onClick={() => setRole(role)}
+              onClick={() => handleRoleSwitch(role)}
               className={cn(
                 'w-full p-4 rounded-lg border-2 text-left transition-colors',
                 currentRole === role

--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -7,6 +7,7 @@ import {
   useEffect,
   useCallback,
   useMemo,
+  useRef,
   ReactNode,
 } from 'react';
 import { Session, User as SupabaseUser } from '@supabase/supabase-js';
@@ -76,7 +77,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     );
   }
 
-  return <ProductionAuthProvider>{children}</ProductionAuthProvider>;
+  return (
+    <ProductionAuthProvider currentRole={currentRole}>
+      {children}
+    </ProductionAuthProvider>
+  );
 }
 
 function DemoAuthProvider({
@@ -104,11 +109,18 @@ function DemoAuthProvider({
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
-function ProductionAuthProvider({ children }: { children: ReactNode }) {
+function ProductionAuthProvider({
+  children,
+  currentRole,
+}: {
+  children: ReactNode;
+  currentRole: UserRole;
+}) {
   const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<AuthContextType['user']>(null);
   const [vendorId, setVendorId] = useState<string | null>(null);
   const [deliveryPersonId, setDeliveryPersonId] = useState<string | null>(null);
+  const provisioningRef = useRef<string | null>(null);
   const supabase = useMemo(() => {
     if (typeof window === 'undefined') return null;
     return createClient();
@@ -135,25 +147,21 @@ function ProductionAuthProvider({ children }: { children: ReactNode }) {
           default_role: profile.default_role,
         });
 
-        // Fetch vendor record if user has vendor role
-        if (profile.roles?.includes('vendor')) {
-          const { data: vendor } = await supabase
-            .from('vendors')
-            .select('id')
-            .eq('user_id', profile.id)
-            .single();
-          setVendorId(vendor?.id || null);
-        }
+        // Eagerly fetch vendor record regardless of user.roles
+        const { data: vendor } = await supabase
+          .from('vendors')
+          .select('id')
+          .eq('user_id', profile.id)
+          .single();
+        setVendorId(vendor?.id || null);
 
-        // Fetch delivery person record if user has delivery role
-        if (profile.roles?.includes('delivery')) {
-          const { data: dp } = await supabase
-            .from('delivery_persons')
-            .select('id')
-            .eq('user_id', profile.id)
-            .single();
-          setDeliveryPersonId(dp?.id || null);
-        }
+        // Eagerly fetch delivery person record regardless of user.roles
+        const { data: dp } = await supabase
+          .from('delivery_persons')
+          .select('id')
+          .eq('user_id', profile.id)
+          .single();
+        setDeliveryPersonId(dp?.id || null);
       }
     },
     [supabase]
@@ -188,6 +196,59 @@ function ProductionAuthProvider({ children }: { children: ReactNode }) {
 
     return () => subscription.unsubscribe();
   }, [supabase, fetchUserProfile]);
+
+  // Lazy provisioning: auto-create vendor/delivery records when role switches
+  useEffect(() => {
+    if (!supabase || !user) return;
+
+    if (currentRole === 'vendor' && !vendorId) {
+      // Prevent duplicate provisioning
+      if (provisioningRef.current === 'vendor') return;
+      provisioningRef.current = 'vendor';
+
+      supabase
+        .from('vendors')
+        .insert({
+          user_id: user.id,
+          name: `${user.name}'s Kitchen`,
+          is_active: true,
+        })
+        .select('id')
+        .single()
+        .then(({ data, error }) => {
+          if (data) {
+            setVendorId(data.id);
+          } else if (error) {
+            console.error('Failed to provision vendor:', error);
+          }
+          provisioningRef.current = null;
+        });
+    }
+
+    if (currentRole === 'delivery' && !deliveryPersonId) {
+      if (provisioningRef.current === 'delivery') return;
+      provisioningRef.current = 'delivery';
+
+      supabase
+        .from('delivery_persons')
+        .insert({
+          user_id: user.id,
+          is_active: true,
+          is_available: true,
+          vehicle_type: 'bike',
+        })
+        .select('id')
+        .single()
+        .then(({ data, error }) => {
+          if (data) {
+            setDeliveryPersonId(data.id);
+          } else if (error) {
+            console.error('Failed to provision delivery person:', error);
+          }
+          provisioningRef.current = null;
+        });
+    }
+  }, [supabase, user, currentRole, vendorId, deliveryPersonId]);
 
   const signIn = useCallback(
     async (email: string, password: string) => {

--- a/src/hooks/use-orders.tsx
+++ b/src/hooks/use-orders.tsx
@@ -69,6 +69,10 @@ export function useVendorOrders(vendorId: string) {
   const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
+    if (!vendorId) {
+      setLoading(false);
+      return;
+    }
     const supabase = createClient();
     const { data, error: fetchError } = await supabase
       .from('orders')
@@ -139,6 +143,10 @@ export function useDeliveryAssignments(deliveryPersonId: string) {
   const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
+    if (!deliveryPersonId) {
+      setLoading(false);
+      return;
+    }
     const supabase = createClient();
     const { data, error: fetchError } = await supabase
       .from('delivery_assignments')

--- a/supabase/migrations/003_insert_policies.sql
+++ b/supabase/migrations/003_insert_policies.sql
@@ -1,0 +1,11 @@
+-- Insert policies for lazy role provisioning
+-- Allows authenticated users to create their own vendor/delivery records when switching roles
+
+CREATE POLICY "Users can insert own vendor" ON public.vendors
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can create own delivery person" ON public.delivery_persons
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own record" ON public.users
+  FOR INSERT WITH CHECK (auth.uid() = id);


### PR DESCRIPTION
## Summary
- Added `AppHeader` component with persistent header on every page (title, DEMO badge, RoleSwitcher avatar, user info, sign-out)
- RoleSwitcher now navigates to the corresponding role page when switching
- Home page role cards call `setRole()` before navigating, removed duplicate headers
- `ProductionAuthProvider` responds to role changes with lazy provisioning: auto-creates vendor/delivery records on first role switch
- Vendor and delivery dashboards handle null IDs gracefully with loading spinners
- Added RLS INSERT policies for `vendors`, `delivery_persons`, and `users` tables

## Test plan
- [x] **Demo mode**: AppHeader visible with DEMO badge and RoleSwitcher on every page, role switching navigates correctly
- [x] **Production mode (not logged in)**: AppHeader shows title only, no RoleSwitcher
- [x] **Production mode (logged in)**: AppHeader shows user name, sign-out, and RoleSwitcher
- [x] **Role switching**: Switch to Vendor → vendor record auto-created → dashboard loads
- [x] **Role switching**: Switch to Delivery → delivery record auto-created → dashboard loads
- [x] **Page refresh**: No UUID errors when refreshing vendor/delivery pages
- [x] `npm run type-check` and `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)