### PR TITLE
Add vendor menu management, shop settings, and UX improvements

### DIFF
--- a/src/app/api/menu-items/[id]/route.ts
+++ b/src/app/api/menu-items/[id]/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getAuthenticatedUser, unauthorizedResponse } from '@/lib/auth/guard';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { error: authError } = await getAuthenticatedUser();
+    if (authError) return unauthorizedResponse();
+
+    const { id } = await params;
+    const supabase = await createClient();
+    const body = await request.json();
+
+    const updates: Record<string, unknown> = {};
+
+    if (body.name !== undefined) updates.name = body.name?.trim();
+    if (body.description !== undefined) updates.description = body.description?.trim() || null;
+    if (body.category !== undefined) updates.category = body.category?.trim() || null;
+    if (body.image_url !== undefined) updates.image_url = body.image_url?.trim() || null;
+    if (body.is_available !== undefined) updates.is_available = body.is_available;
+
+    if (body.price !== undefined) {
+      if (typeof body.price !== 'number' || body.price < 0) {
+        return NextResponse.json({ error: 'price must be a non-negative number' }, { status: 400 });
+      }
+      updates.price = body.price;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ error: 'No fields to update' }, { status: 400 });
+    }
+
+    const { data: item, error } = await supabase
+      .from('menu_items')
+      .update(updates)
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Menu item update error:', error);
+      return NextResponse.json({ error: 'Failed to update menu item' }, { status: 500 });
+    }
+
+    return NextResponse.json({ item });
+  } catch (error) {
+    console.error('Menu item PATCH error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/menu-items/route.ts
+++ b/src/app/api/menu-items/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getAuthenticatedUser, unauthorizedResponse } from '@/lib/auth/guard';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { error: authError } = await getAuthenticatedUser();
+    if (authError) return unauthorizedResponse();
+
+    const supabase = await createClient();
+    const { searchParams } = new URL(request.url);
+    const vendor_id = searchParams.get('vendor_id');
+
+    if (!vendor_id) {
+      return NextResponse.json({ error: 'vendor_id is required' }, { status: 400 });
+    }
+
+    const { data: items, error } = await supabase
+      .from('menu_items')
+      .select('*')
+      .eq('vendor_id', vendor_id)
+      .order('category', { ascending: true, nullsFirst: false })
+      .order('name', { ascending: true });
+
+    if (error) {
+      console.error('Menu items fetch error:', error);
+      return NextResponse.json({ error: 'Failed to fetch menu items' }, { status: 500 });
+    }
+
+    return NextResponse.json({ items });
+  } catch (error) {
+    console.error('Menu items GET error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const { error: authError } = await getAuthenticatedUser();
+    if (authError) return unauthorizedResponse();
+
+    const supabase = await createClient();
+    const { searchParams } = new URL(request.url);
+    const vendor_id = searchParams.get('vendor_id');
+
+    if (!vendor_id) {
+      return NextResponse.json({ error: 'vendor_id is required' }, { status: 400 });
+    }
+
+    const { error } = await supabase
+      .from('menu_items')
+      .delete()
+      .eq('vendor_id', vendor_id);
+
+    if (error) {
+      console.error('Menu items bulk delete error:', error);
+      return NextResponse.json({ error: 'Failed to clear menu items' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Menu items DELETE error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { error: authError } = await getAuthenticatedUser();
+    if (authError) return unauthorizedResponse();
+
+    const supabase = await createClient();
+    const body = await request.json();
+
+    const { vendor_id, name, price, description, category, image_url, is_available } = body;
+
+    if (!vendor_id || !name?.trim()) {
+      return NextResponse.json({ error: 'vendor_id and name are required' }, { status: 400 });
+    }
+
+    if (price === undefined || price === null || typeof price !== 'number' || price < 0) {
+      return NextResponse.json({ error: 'price must be a non-negative number' }, { status: 400 });
+    }
+
+    const { data: item, error } = await supabase
+      .from('menu_items')
+      .insert({
+        vendor_id,
+        name: name.trim(),
+        description: description?.trim() || null,
+        price,
+        category: category?.trim() || null,
+        image_url: image_url?.trim() || null,
+        is_available: is_available ?? true,
+      } as Record<string, unknown>)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Menu item create error:', error);
+      return NextResponse.json({ error: 'Failed to create menu item' }, { status: 500 });
+    }
+
+    return NextResponse.json({ item }, { status: 201 });
+  } catch (error) {
+    console.error('Menu items POST error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/vendors/[id]/route.ts
+++ b/src/app/api/vendors/[id]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getAuthenticatedUser, unauthorizedResponse } from '@/lib/auth/guard';
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { error: authError } = await getAuthenticatedUser();
+    if (authError) return unauthorizedResponse();
+
+    const { id } = await params;
+    const supabase = await createClient();
+    const body = await request.json();
+
+    const updates: Record<string, unknown> = {};
+    if (body.name !== undefined) updates.name = body.name?.trim();
+    if (body.address !== undefined) updates.address = body.address?.trim() || null;
+    if (body.description !== undefined) updates.description = body.description?.trim() || null;
+    if (body.is_active !== undefined) updates.is_active = body.is_active;
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ error: 'No fields to update' }, { status: 400 });
+    }
+
+    const { data: vendor, error } = await supabase
+      .from('vendors')
+      .update(updates)
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Vendor update error:', error);
+      return NextResponse.json({ error: 'Failed to update vendor' }, { status: 500 });
+    }
+
+    return NextResponse.json({ vendor });
+  } catch (error) {
+    console.error('Vendor PATCH error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { error: authError } = await getAuthenticatedUser();
+    if (authError) return unauthorizedResponse();
+
+    const { id } = await params;
+    const supabase = await createClient();
+
+    const { error } = await supabase
+      .from('vendors')
+      .update({ is_active: false })
+      .eq('id', id);
+
+    if (error) {
+      console.error('Vendor deactivate error:', error);
+      return NextResponse.json({ error: 'Failed to deactivate vendor' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Vendor DELETE error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -8,6 +9,12 @@ import { ShoppingBag, Store, Truck } from "lucide-react";
 import { useAuth } from "@/hooks/use-auth";
 import { useRole } from "@/hooks/use-role";
 import type { UserRole } from "@/types";
+
+const roleRoutes: Record<string, string> = {
+  customer: '/vendors',
+  vendor: '/vendor',
+  delivery: '/delivery',
+};
 
 const roles = [
   {
@@ -47,47 +54,22 @@ export default function Home() {
   const { setRole } = useRole();
   const router = useRouter();
 
+  useEffect(() => {
+    if (user && !loading) {
+      const role = user.default_role || 'customer';
+      setRole(role as UserRole);
+      router.replace(roleRoutes[role] ?? '/vendors');
+    }
+  }, [user, loading, router, setRole]);
+
   const handleRoleClick = (role: UserRole, href: string) => {
     setRole(role);
     router.push(href);
   };
 
-  // Authenticated user: show role-based navigation
+  // Authenticated user: redirect in progress
   if (user && !loading) {
-    return (
-      <main className="container px-4 py-8">
-        <div className="mx-auto max-w-3xl space-y-8">
-          <div className="text-center space-y-2">
-            <p className="text-lg text-muted-foreground">
-              Welcome back, {user.name}
-            </p>
-            <p className="text-sm text-muted-foreground">
-              Select a role to continue
-            </p>
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-3">
-            {roles.map((role) => (
-              <button key={role.name} onClick={() => handleRoleClick(role.role, role.href)} className="text-left">
-                <Card className={`h-full transition-colors border-2 ${role.borderColor} ${role.hoverBg} cursor-pointer`}>
-                  <CardHeader className="text-center pb-2">
-                    <div className={`mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full ${role.color} text-white`}>
-                      <role.icon className="h-6 w-6" />
-                    </div>
-                    <CardTitle className="text-lg">{role.name}</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <CardDescription className="text-center">
-                      {role.description}
-                    </CardDescription>
-                  </CardContent>
-                </Card>
-              </button>
-            ))}
-          </div>
-        </div>
-      </main>
-    );
+    return null;
   }
 
   // Not authenticated: show sign-in / create account

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -3,41 +3,12 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { Mail, Phone, Lock, User, Loader2, ShoppingBag, Store, Truck } from 'lucide-react';
+import { Mail, Phone, Lock, User, Loader2 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useAuth } from '@/hooks/use-auth';
-import type { UserRole } from '@/types';
-
 type AuthMethod = 'email' | 'phone';
-
-const roleOptions = [
-  {
-    value: 'customer' as UserRole,
-    label: 'Customer',
-    description: 'Order food from local vendors',
-    icon: ShoppingBag,
-    color: 'border-green-500 bg-green-50 dark:bg-green-950',
-    selectedColor: 'border-green-500 ring-2 ring-green-500',
-  },
-  {
-    value: 'vendor' as UserRole,
-    label: 'Vendor',
-    description: 'Sell food to the community',
-    icon: Store,
-    color: 'border-amber-500 bg-amber-50 dark:bg-amber-950',
-    selectedColor: 'border-amber-500 ring-2 ring-amber-500',
-  },
-  {
-    value: 'delivery' as UserRole,
-    label: 'Delivery',
-    description: 'Deliver orders in your area',
-    icon: Truck,
-    color: 'border-blue-500 bg-blue-50 dark:bg-blue-950',
-    selectedColor: 'border-blue-500 ring-2 ring-blue-500',
-  },
-];
 
 export default function RegisterPage() {
   const router = useRouter();
@@ -46,7 +17,6 @@ export default function RegisterPage() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [role, setRole] = useState<UserRole>('customer');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -62,7 +32,7 @@ export default function RegisterPage() {
     setLoading(true);
     setError(null);
 
-    const { error: signUpError } = await signUp(email.trim(), password, name.trim(), role);
+    const { error: signUpError } = await signUp(email.trim(), password, name.trim(), 'customer');
 
     if (signUpError) {
       setError(signUpError);
@@ -164,29 +134,6 @@ export default function RegisterPage() {
                   minLength={6}
                   required
                 />
-              </div>
-
-              {/* Role Selection */}
-              <div className="space-y-2">
-                <label className="text-sm font-medium">I want to...</label>
-                <div className="grid grid-cols-3 gap-2">
-                  {roleOptions.map((opt) => (
-                    <button
-                      key={opt.value}
-                      type="button"
-                      onClick={() => setRole(opt.value)}
-                      className={`p-3 rounded-lg border-2 text-center transition-all ${
-                        role === opt.value ? opt.selectedColor : opt.color
-                      }`}
-                    >
-                      <opt.icon className="w-5 h-5 mx-auto mb-1" />
-                      <span className="text-xs font-medium block">{opt.label}</span>
-                    </button>
-                  ))}
-                </div>
-                <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
-                  {roleOptions.find((o) => o.value === role)?.description}
-                </p>
               </div>
 
               {error && (

--- a/src/app/vendor/menu/page.tsx
+++ b/src/app/vendor/menu/page.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { UtensilsCrossed, Power, Pencil, Plus, ArrowLeft } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
+import Link from 'next/link';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/hooks/use-auth';
+import { MenuItemDialog } from '@/components/menu-item-dialog';
+import type { MenuItem } from '@/lib/supabase/types';
+
+export default function VendorMenuPage() {
+  const { vendorId } = useAuth();
+  const [items, setItems] = useState<MenuItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [toggling, setToggling] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editItem, setEditItem] = useState<MenuItem | undefined>(undefined);
+
+  useEffect(() => {
+    if (!vendorId) return;
+    fetchItems();
+  }, [vendorId]);
+
+  const fetchItems = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/menu-items?vendor_id=${vendorId}`);
+      const data = await res.json();
+      if (res.ok) setItems(data.items ?? []);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleToggle = async (item: MenuItem) => {
+    setToggling(item.id);
+    try {
+      const res = await fetch(`/api/menu-items/${item.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ is_available: !item.is_available }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setItems((prev) => prev.map((i) => (i.id === item.id ? data.item : i)));
+      }
+    } finally {
+      setToggling(null);
+    }
+  };
+
+  const handleDialogSuccess = (savedItem: MenuItem) => {
+    setItems((prev) => {
+      const exists = prev.find((i) => i.id === savedItem.id);
+      return exists
+        ? prev.map((i) => (i.id === savedItem.id ? savedItem : i))
+        : [...prev, savedItem];
+    });
+  };
+
+  const openAdd = () => {
+    setEditItem(undefined);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (item: MenuItem) => {
+    setEditItem(item);
+    setDialogOpen(true);
+  };
+
+  if (!vendorId) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-8 h-8 border-4 border-amber-500 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-gray-500 dark:text-gray-400">Setting up vendor account...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Group items by category
+  const grouped = items.reduce<Record<string, MenuItem[]>>((acc, item) => {
+    const key = item.category?.trim() || 'Uncategorized';
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(item);
+    return acc;
+  }, {});
+
+  const sortedCategories = Object.keys(grouped).sort((a, b) => {
+    if (a === 'Uncategorized') return 1;
+    if (b === 'Uncategorized') return -1;
+    return a.localeCompare(b);
+  });
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <header className="bg-amber-600 text-white">
+        <div className="max-w-2xl mx-auto px-4 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Link href="/vendor">
+                <Button variant="ghost" size="sm" className="text-white hover:bg-amber-700 -ml-2">
+                  <ArrowLeft className="w-4 h-4" />
+                </Button>
+              </Link>
+              <UtensilsCrossed className="w-6 h-6" />
+              <div>
+                <h1 className="text-xl font-bold">Menu Management</h1>
+                <p className="text-sm text-amber-100">Manage your menu items</p>
+              </div>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="bg-white text-amber-600 hover:bg-amber-50 border-white"
+              onClick={openAdd}
+            >
+              <Plus className="w-4 h-4 mr-2" />
+              Add Item
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 py-6">
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="w-6 h-6 animate-spin text-amber-500" />
+          </div>
+        ) : items.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center">
+              <UtensilsCrossed className="w-12 h-12 mx-auto text-gray-300 dark:text-gray-600 mb-4" />
+              <p className="text-gray-500 dark:text-gray-400 mb-4">
+                No menu items yet. Add your first item to get started.
+              </p>
+              <Button
+                className="bg-amber-600 hover:bg-amber-700"
+                onClick={openAdd}
+              >
+                <Plus className="w-4 h-4 mr-2" />
+                Add First Item
+              </Button>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-6">
+            {sortedCategories.map((category) => (
+              <div key={category}>
+                <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">
+                  {category}
+                </h2>
+                <div className="space-y-2">
+                  {grouped[category].map((item) => (
+                    <Card key={item.id}>
+                      <CardContent className="py-3 px-4">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <span className="font-medium text-gray-900 dark:text-white">
+                                {item.name}
+                              </span>
+                              <span
+                                className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                                  item.is_available
+                                    ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
+                                    : 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400'
+                                }`}
+                              >
+                                {item.is_available ? 'Available' : 'Unavailable'}
+                              </span>
+                            </div>
+                            {item.description && (
+                              <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5 truncate">
+                                {item.description}
+                              </p>
+                            )}
+                            <p className="text-sm font-semibold text-amber-600 mt-1">
+                              ${Number(item.price).toFixed(2)}
+                            </p>
+                          </div>
+                          <div className="flex items-center gap-2 shrink-0">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => openEdit(item)}
+                            >
+                              <Pencil className="w-3.5 h-3.5" />
+                            </Button>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => handleToggle(item)}
+                              disabled={toggling === item.id}
+                              title={item.is_available ? 'Mark unavailable' : 'Mark available'}
+                            >
+                              {toggling === item.id ? (
+                                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                              ) : (
+                                <Power className="w-3.5 h-3.5" />
+                              )}
+                            </Button>
+                          </div>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </main>
+
+      <MenuItemDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        vendorId={vendorId}
+        item={editItem}
+        onSuccess={handleDialogSuccess}
+      />
+    </div>
+  );
+}

--- a/src/app/vendor/page.tsx
+++ b/src/app/vendor/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Store, Clock, ChefHat, Package, Loader2, CheckCircle2 } from 'lucide-react';
+import Link from 'next/link';
+import { Store, Clock, ChefHat, Package, Loader2, CheckCircle2, UtensilsCrossed, Settings } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
@@ -69,11 +70,26 @@ export default function VendorDashboard() {
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <header className="bg-amber-600 text-white">
         <div className="max-w-2xl mx-auto px-4 py-4">
-          <div className="flex items-center gap-3">
-            <Store className="w-6 h-6" />
-            <div>
-              <h1 className="text-xl font-bold">Vendor Dashboard</h1>
-              <p className="text-sm text-amber-100">Maria&apos;s Kitchen</p>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Store className="w-6 h-6" />
+              <div>
+                <h1 className="text-xl font-bold">Vendor Dashboard</h1>
+                <p className="text-sm text-amber-100">Maria&apos;s Kitchen</p>
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <Link href="/vendor/menu">
+                <Button variant="outline" size="sm" className="bg-white text-amber-600 hover:bg-amber-50 border-white">
+                  <UtensilsCrossed className="w-4 h-4 mr-2" />
+                  Menu
+                </Button>
+              </Link>
+              <Link href="/vendor/settings">
+                <Button variant="outline" size="sm" className="bg-white text-amber-600 hover:bg-amber-50 border-white">
+                  <Settings className="w-4 h-4" />
+                </Button>
+              </Link>
             </div>
           </div>
         </div>

--- a/src/app/vendor/settings/page.tsx
+++ b/src/app/vendor/settings/page.tsx
@@ -1,0 +1,275 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft, Loader2, Settings } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useAuth } from '@/hooks/use-auth';
+import { createClient } from '@/lib/supabase/client';
+import Link from 'next/link';
+
+export default function VendorSettingsPage() {
+  const { vendorId } = useAuth();
+  const router = useRouter();
+
+  const [name, setName] = useState('');
+  const [address, setAddress] = useState('');
+  const [loadingProfile, setLoadingProfile] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  const [clearingMenu, setClearingMenu] = useState(false);
+  const [deactivating, setDeactivating] = useState(false);
+  const [confirmClear, setConfirmClear] = useState(false);
+  const [confirmDeactivate, setConfirmDeactivate] = useState(false);
+
+  useEffect(() => {
+    if (!vendorId) return;
+
+    const supabase = createClient();
+    supabase
+      .from('vendors')
+      .select('name, address')
+      .eq('id', vendorId)
+      .single()
+      .then(({ data }) => {
+        if (data) {
+          setName(data.name ?? '');
+          setAddress(data.address ?? '');
+        }
+        setLoadingProfile(false);
+      });
+  }, [vendorId]);
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!vendorId) return;
+    setSaving(true);
+    setSaveError(null);
+    setSaveSuccess(false);
+
+    const res = await fetch(`/api/vendors/${vendorId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: name.trim(), address: address.trim() }),
+    });
+
+    if (res.ok) {
+      setSaveSuccess(true);
+      setTimeout(() => setSaveSuccess(false), 3000);
+    } else {
+      const data = await res.json();
+      setSaveError(data.error ?? 'Failed to save');
+    }
+    setSaving(false);
+  };
+
+  const handleClearMenu = async () => {
+    if (!vendorId) return;
+    setClearingMenu(true);
+    const res = await fetch(`/api/menu-items?vendor_id=${vendorId}`, { method: 'DELETE' });
+    setClearingMenu(false);
+    setConfirmClear(false);
+    if (!res.ok) alert('Failed to clear menu. Please try again.');
+  };
+
+  const handleDeactivate = async () => {
+    if (!vendorId) return;
+    setDeactivating(true);
+    const res = await fetch(`/api/vendors/${vendorId}`, {
+      method: 'DELETE',
+    });
+    setDeactivating(false);
+    setConfirmDeactivate(false);
+    if (res.ok) {
+      router.push('/');
+    } else {
+      alert('Failed to deactivate shop. Please try again.');
+    }
+  };
+
+  if (!vendorId) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-8 h-8 border-4 border-amber-500 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-gray-500 dark:text-gray-400">Setting up vendor account...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <header className="bg-amber-600 text-white">
+        <div className="max-w-2xl mx-auto px-4 py-4">
+          <div className="flex items-center gap-3">
+            <Link href="/vendor">
+              <Button variant="ghost" size="sm" className="text-white hover:bg-amber-700 -ml-2">
+                <ArrowLeft className="w-4 h-4" />
+              </Button>
+            </Link>
+            <Settings className="w-6 h-6" />
+            <div>
+              <h1 className="text-xl font-bold">Shop Settings</h1>
+              <p className="text-sm text-amber-100">Manage your shop details</p>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 py-6 space-y-6">
+        {/* Shop details form */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Shop Details</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loadingProfile ? (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="w-5 h-5 animate-spin text-amber-500" />
+              </div>
+            ) : (
+              <form onSubmit={handleSave} className="space-y-4">
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Shop Name</label>
+                  <Input
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="e.g. Maria's Kitchen"
+                    required
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Location / Address</label>
+                  <Input
+                    value={address}
+                    onChange={(e) => setAddress(e.target.value)}
+                    placeholder="e.g. 123 Market St, Building B"
+                  />
+                </div>
+
+                {saveError && (
+                  <div className="p-3 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-lg text-sm text-center">
+                    {saveError}
+                  </div>
+                )}
+                {saveSuccess && (
+                  <div className="p-3 bg-green-50 dark:bg-green-950 text-green-600 dark:text-green-400 rounded-lg text-sm text-center">
+                    Saved successfully
+                  </div>
+                )}
+
+                <Button
+                  type="submit"
+                  className="w-full bg-amber-600 hover:bg-amber-700"
+                  disabled={saving}
+                >
+                  {saving ? (
+                    <>
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      Saving...
+                    </>
+                  ) : (
+                    'Save Changes'
+                  )}
+                </Button>
+              </form>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Danger zone */}
+        <Card className="border-red-200 dark:border-red-800">
+          <CardHeader>
+            <CardTitle className="text-base text-red-600 dark:text-red-400">Danger Zone</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {/* Clear menu */}
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium">Clear Menu</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Permanently delete all menu items
+                </p>
+              </div>
+              {confirmClear ? (
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setConfirmClear(false)}
+                    disabled={clearingMenu}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    size="sm"
+                    className="bg-red-600 hover:bg-red-700 text-white"
+                    onClick={handleClearMenu}
+                    disabled={clearingMenu}
+                  >
+                    {clearingMenu ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Confirm'}
+                  </Button>
+                </div>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-red-300 text-red-600 hover:bg-red-50 dark:border-red-700 dark:text-red-400"
+                  onClick={() => setConfirmClear(true)}
+                >
+                  Clear Menu
+                </Button>
+              )}
+            </div>
+
+            <div className="border-t dark:border-gray-700" />
+
+            {/* Deactivate shop */}
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium">Deactivate Shop</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Hides your shop from customers
+                </p>
+              </div>
+              {confirmDeactivate ? (
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setConfirmDeactivate(false)}
+                    disabled={deactivating}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    size="sm"
+                    className="bg-red-600 hover:bg-red-700 text-white"
+                    onClick={handleDeactivate}
+                    disabled={deactivating}
+                  >
+                    {deactivating ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Confirm'}
+                  </Button>
+                </div>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="border-red-300 text-red-600 hover:bg-red-50 dark:border-red-700 dark:text-red-400"
+                  onClick={() => setConfirmDeactivate(true)}
+                >
+                  Deactivate
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/src/app/vendors/page.tsx
+++ b/src/app/vendors/page.tsx
@@ -11,7 +11,8 @@ export default async function VendorsPage() {
   const { data: vendors } = await supabase
     .from('vendors')
     .select('*')
-    .eq('is_active', true) as { data: Vendor[] | null };
+    .eq('is_active', true)
+    .order('created_at', { ascending: true }) as { data: Vendor[] | null };
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">

--- a/src/components/menu-item-dialog.tsx
+++ b/src/components/menu-item-dialog.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Loader2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import type { MenuItem } from '@/lib/supabase/types';
+
+interface MenuItemDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  vendorId: string;
+  item?: MenuItem;
+  onSuccess: (item: MenuItem) => void;
+}
+
+export function MenuItemDialog({
+  open,
+  onOpenChange,
+  vendorId,
+  item,
+  onSuccess,
+}: MenuItemDialogProps) {
+  const isEdit = !!item;
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [price, setPrice] = useState('');
+  const [category, setCategory] = useState('');
+  const [imageUrl, setImageUrl] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setName(item?.name ?? '');
+      setDescription(item?.description ?? '');
+      setPrice(item?.price !== undefined ? String(item.price) : '');
+      setCategory(item?.category ?? '');
+      setImageUrl(item?.image_url ?? '');
+      setError(null);
+    }
+  }, [open, item]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!name.trim()) return;
+    const parsedPrice = parseFloat(price);
+    if (isNaN(parsedPrice) || parsedPrice < 0) {
+      setError('Price must be a non-negative number');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const url = isEdit
+        ? `/api/menu-items/${item!.id}`
+        : '/api/menu-items';
+      const method = isEdit ? 'PATCH' : 'POST';
+      const body = isEdit
+        ? { name: name.trim(), description, price: parsedPrice, category, image_url: imageUrl }
+        : { vendor_id: vendorId, name: name.trim(), description, price: parsedPrice, category, image_url: imageUrl };
+
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error ?? 'Something went wrong');
+        return;
+      }
+
+      onSuccess(data.item);
+      onOpenChange(false);
+    } catch {
+      setError('Network error. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit Item' : 'Add Menu Item'}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4 mt-2">
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Name *</label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Jollof Rice"
+              required
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Description</label>
+            <Input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Short description"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Price *</label>
+            <Input
+              type="number"
+              min="0"
+              step="0.01"
+              value={price}
+              onChange={(e) => setPrice(e.target.value)}
+              placeholder="0.00"
+              required
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Category</label>
+            <Input
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              placeholder="e.g. Mains, Drinks, Sides"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Image URL</label>
+            <Input
+              value={imageUrl}
+              onChange={(e) => setImageUrl(e.target.value)}
+              placeholder="https://..."
+            />
+          </div>
+
+          {error && (
+            <div className="p-3 bg-red-50 dark:bg-red-950 text-red-600 dark:text-red-400 rounded-lg text-sm text-center">
+              {error}
+            </div>
+          )}
+
+          <div className="flex gap-2 justify-end pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              className="bg-amber-600 hover:bg-amber-700"
+              disabled={loading}
+            >
+              {loading ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  Saving...
+                </>
+              ) : isEdit ? (
+                'Save Changes'
+              ) : (
+                'Add Item'
+              )}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/shared/app-header.tsx
+++ b/src/components/shared/app-header.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { useAuth } from '@/hooks/use-auth';
 import { RoleSwitcher } from '@/components/shared/role-switcher';
 import { Button } from '@/components/ui/button';
@@ -7,6 +8,12 @@ import { LogOut } from 'lucide-react';
 
 export function AppHeader() {
   const { user, loading, signOut } = useAuth();
+  const router = useRouter();
+
+  const handleSignOut = async () => {
+    await signOut();
+    router.push('/');
+  };
 
   const showRoleSwitcher = !loading && user;
 
@@ -22,7 +29,7 @@ export function AppHeader() {
             <span className="text-sm text-muted-foreground hidden sm:inline">
               {user.name}
             </span>
-            <Button variant="ghost" size="sm" onClick={signOut}>
+            <Button variant="ghost" size="sm" onClick={handleSignOut}>
               <LogOut className="h-4 w-4" />
             </Button>
             <RoleSwitcher

--- a/src/components/shared/role-switcher.tsx
+++ b/src/components/shared/role-switcher.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
@@ -9,7 +10,16 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
 import { useRole } from '@/hooks/use-role';
+import { useAuth } from '@/hooks/use-auth';
+import { createClient } from '@/lib/supabase/client';
 import type { UserRole } from '@/types';
 import { cn } from '@/lib/utils';
 
@@ -46,67 +56,128 @@ export function RoleSwitcher({
   availableRoles = ['customer', 'vendor', 'delivery'],
 }: RoleSwitcherProps) {
   const { currentRole, setRole, roleColor } = useRole();
+  const { user, addRole } = useAuth();
   const router = useRouter();
+  const supabase = useMemo(() => createClient(), []);
 
-  const handleRoleSwitch = (role: UserRole) => {
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [confirmRole, setConfirmRole] = useState<UserRole | null>(null);
+  const [adding, setAdding] = useState(false);
+
+  const userRoles = user?.roles ?? ['customer'];
+
+  const switchToRole = (role: UserRole) => {
     setRole(role);
     router.push(roleRoutes[role]);
+    setSheetOpen(false);
+    if (user?.id) {
+      supabase.from('users').update({ default_role: role }).eq('id', user.id);
+    }
+  };
+
+  const handleRoleClick = (role: UserRole) => {
+    if (userRoles.includes(role)) {
+      switchToRole(role);
+    } else {
+      setConfirmRole(role);
+    }
+  };
+
+  const handleConfirmAddRole = async () => {
+    if (!confirmRole) return;
+    setAdding(true);
+    await addRole(confirmRole);
+    setAdding(false);
+    switchToRole(confirmRole);
+    setConfirmRole(null);
   };
 
   return (
-    <Sheet>
-      <SheetTrigger asChild>
-        <button className="focus:outline-none focus:ring-2 focus:ring-ring rounded-full">
-          <Avatar
-            className={cn(
-              'ring-2 ring-offset-2 ring-offset-background cursor-pointer',
-              currentRole === 'customer' && 'ring-role-customer',
-              currentRole === 'vendor' && 'ring-role-vendor',
-              currentRole === 'delivery' && 'ring-role-delivery'
-            )}
-          >
-            <AvatarImage src={avatarUrl} alt="User avatar" />
-            <AvatarFallback
+    <>
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetTrigger asChild>
+          <button className="focus:outline-none focus:ring-2 focus:ring-ring rounded-full">
+            <Avatar
               className={cn(
-                currentRole === 'customer' && 'bg-role-customer text-role-customer-foreground',
-                currentRole === 'vendor' && 'bg-role-vendor text-role-vendor-foreground',
-                currentRole === 'delivery' && 'bg-role-delivery text-role-delivery-foreground'
+                'ring-2 ring-offset-2 ring-offset-background cursor-pointer',
+                currentRole === 'customer' && 'ring-role-customer',
+                currentRole === 'vendor' && 'ring-role-vendor',
+                currentRole === 'delivery' && 'ring-role-delivery'
               )}
             >
-              {userInitials}
-            </AvatarFallback>
-          </Avatar>
-        </button>
-      </SheetTrigger>
-      <SheetContent side="right" className="w-80">
-        <SheetHeader>
-          <SheetTitle>What are you today?</SheetTitle>
-        </SheetHeader>
-        <div className="mt-6 space-y-3">
-          {availableRoles.map((role) => (
-            <button
-              key={role}
-              onClick={() => handleRoleSwitch(role)}
-              className={cn(
-                'w-full p-4 rounded-lg border-2 text-left transition-colors',
-                currentRole === role
-                  ? cn(
-                      'border-2',
-                      role === 'customer' && 'border-role-customer bg-role-customer/10',
-                      role === 'vendor' && 'border-role-vendor bg-role-vendor/10',
-                      role === 'delivery' && 'border-role-delivery bg-role-delivery/10'
-                    )
-                  : 'border-border hover:border-muted-foreground/50'
-              )}
-            >
-              <div className="font-medium">{roleConfig[role].label}</div>
-              <div className="text-sm text-muted-foreground">
-                {roleConfig[role].description}
-              </div>
-            </button>
-          ))}
-        </div>
-      </SheetContent>
-    </Sheet>
+              <AvatarImage src={avatarUrl} alt="User avatar" />
+              <AvatarFallback
+                className={cn(
+                  currentRole === 'customer' && 'bg-role-customer text-role-customer-foreground',
+                  currentRole === 'vendor' && 'bg-role-vendor text-role-vendor-foreground',
+                  currentRole === 'delivery' && 'bg-role-delivery text-role-delivery-foreground'
+                )}
+              >
+                {userInitials}
+              </AvatarFallback>
+            </Avatar>
+          </button>
+        </SheetTrigger>
+        <SheetContent side="right" className="w-80">
+          <SheetHeader>
+            <SheetTitle>What are you today?</SheetTitle>
+          </SheetHeader>
+          <div className="mt-6 space-y-3">
+            {availableRoles.map((role) => {
+              const hasRole = userRoles.includes(role);
+              return (
+                <button
+                  key={role}
+                  onClick={() => handleRoleClick(role)}
+                  className={cn(
+                    'w-full p-4 rounded-lg border-2 text-left transition-colors',
+                    currentRole === role
+                      ? cn(
+                          'border-2',
+                          role === 'customer' && 'border-role-customer bg-role-customer/10',
+                          role === 'vendor' && 'border-role-vendor bg-role-vendor/10',
+                          role === 'delivery' && 'border-role-delivery bg-role-delivery/10'
+                        )
+                      : 'border-border hover:border-muted-foreground/50'
+                  )}
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="font-medium">{roleConfig[role].label}</div>
+                    {!hasRole && (
+                      <span className="text-xs text-muted-foreground border rounded px-1.5 py-0.5">
+                        + Add
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    {roleConfig[role].description}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <Dialog open={!!confirmRole} onOpenChange={(open) => !open && setConfirmRole(null)}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Add {confirmRole ? roleConfig[confirmRole].label : ''} role?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            This will add the <strong>{confirmRole ? roleConfig[confirmRole].label : ''}</strong> role to your account.{' '}
+            {roleConfig[confirmRole ?? 'customer'].description}.
+          </p>
+          <div className="flex gap-2 justify-end mt-2">
+            <Button variant="outline" onClick={() => setConfirmRole(null)} disabled={adding}>
+              Cancel
+            </Button>
+            <Button onClick={handleConfirmAddRole} disabled={adding}>
+              {adding ? 'Adding...' : 'Add Role'}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -33,6 +33,7 @@ interface AuthContextType {
     role: UserRole
   ) => Promise<{ error: string | null }>;
   signOut: () => Promise<void>;
+  addRole: (role: UserRole) => Promise<void>;
   userId: string | null;
   vendorId: string | null;
   deliveryPersonId: string | null;
@@ -205,7 +206,7 @@ function ProductionAuthProvider({
   );
 
   const signUp = useCallback(
-    async (email: string, password: string, name: string, role: UserRole) => {
+    async (email: string, password: string, name: string, _role: UserRole) => {
       if (!supabase) return { error: 'Not initialized' };
       const { data, error } = await supabase.auth.signUp({
         email,
@@ -214,39 +215,39 @@ function ProductionAuthProvider({
       if (error) return { error: error.message };
       if (!data.user) return { error: 'Sign up failed' };
 
-      // Create public.users record
+      // All new users start as customer
       const { error: profileError } = await supabase.from('users').insert({
         id: data.user.id,
         email,
         name,
         phone: '',
-        roles: [role],
-        default_role: role,
+        roles: ['customer'],
+        default_role: 'customer',
       });
 
       if (profileError) {
         return { error: 'Account created but profile setup failed. Please contact support.' };
       }
 
-      // Create role-specific records
-      if (role === 'vendor') {
-        await supabase.from('vendors').insert({
-          user_id: data.user.id,
-          name: `${name}'s Kitchen`,
-          is_active: true,
-        });
-      } else if (role === 'delivery') {
-        await supabase.from('delivery_persons').insert({
-          user_id: data.user.id,
-          is_active: true,
-          is_available: true,
-          vehicle_type: 'bike',
-        });
-      }
-
       return { error: null };
     },
     [supabase]
+  );
+
+  const addRole = useCallback(
+    async (role: UserRole) => {
+      if (!supabase || !user) return;
+      if (user.roles.includes(role)) return;
+      const newRoles = [...user.roles, role];
+      const { error } = await supabase
+        .from('users')
+        .update({ roles: newRoles })
+        .eq('id', user.id);
+      if (!error) {
+        setUser((prev) => (prev ? { ...prev, roles: newRoles } : prev));
+      }
+    },
+    [supabase, user]
   );
 
   const signOut = useCallback(async () => {
@@ -265,11 +266,12 @@ function ProductionAuthProvider({
       signIn,
       signUp,
       signOut,
+      addRole,
       userId: user?.id || null,
       vendorId,
       deliveryPersonId,
     }),
-    [user, session, loading, signIn, signUp, signOut, vendorId, deliveryPersonId]
+    [user, session, loading, signIn, signUp, signOut, addRole, vendorId, deliveryPersonId]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/supabase/migrations/004_menu_items_policies.sql
+++ b/supabase/migrations/004_menu_items_policies.sql
@@ -1,0 +1,11 @@
+-- RLS policies for vendors to manage their own menu items
+
+CREATE POLICY "Vendors can insert own menu items" ON public.menu_items
+  FOR INSERT WITH CHECK (
+    vendor_id IN (SELECT id FROM public.vendors WHERE user_id = auth.uid())
+  );
+
+CREATE POLICY "Vendors can update own menu items" ON public.menu_items
+  FOR UPDATE USING (
+    vendor_id IN (SELECT id FROM public.vendors WHERE user_id = auth.uid())
+  );

--- a/supabase/migrations/005_update_policies.sql
+++ b/supabase/migrations/005_update_policies.sql
@@ -1,0 +1,13 @@
+-- Allow users to update their own profile (e.g. adding roles)
+CREATE POLICY "Users can update own profile" ON public.users
+  FOR UPDATE USING (auth.uid() = id);
+
+-- Allow vendors to update their own vendor record (name, address, is_active)
+CREATE POLICY "Vendors can update own vendor" ON public.vendors
+  FOR UPDATE USING (auth.uid() = user_id);
+
+-- Allow vendors to delete their own menu items (for bulk clear)
+CREATE POLICY "Vendors can delete own menu items" ON public.menu_items
+  FOR DELETE USING (
+    vendor_id IN (SELECT id FROM public.vendors WHERE user_id = auth.uid())
+  );

--- a/supabase/migrations/006_vendor_user_unique.sql
+++ b/supabase/migrations/006_vendor_user_unique.sql
@@ -1,0 +1,11 @@
+-- Ensure each user can only have one vendor record
+-- Before adding constraint, remove any duplicates by keeping the oldest per user_id
+DELETE FROM public.vendors
+WHERE id NOT IN (
+  SELECT DISTINCT ON (user_id) id
+  FROM public.vendors
+  ORDER BY user_id, created_at ASC
+);
+
+ALTER TABLE public.vendors
+  ADD CONSTRAINT vendors_user_id_unique UNIQUE (user_id);


### PR DESCRIPTION
## Summary

- **Vendor menu management** — new `/vendor/menu` page to add, edit, and toggle availability of menu items, with a reusable dialog component
- **Shop settings** — new `/vendor/settings` page to update shop name and address, with a danger zone to clear the menu or deactivate the shop
- **Auth UX** — logout redirects to home; new users default to customer role; role switcher prompts before adding a new role; role switches persist as `default_role` so login skips the role picker and goes directly to the last-used page
- **Bug fixes** — duplicate vendors prevented via unique constraint on `vendors.user_id`; back navigation added to menu and settings pages

## Migrations to run in Supabase SQL Editor

| File | Description |
|---|---|
| `004_menu_items_policies.sql` | INSERT + UPDATE RLS for vendor-owned menu items |
| `005_update_policies.sql` | UPDATE RLS for users, vendors, and DELETE for menu items |
| `006_vendor_user_unique.sql` | Removes duplicate vendors and adds unique constraint on `user_id` |

## Test plan

- [ ] Log in as `vendor@demo.firefly` → lands directly on `/vendor` (no role picker)
- [ ] Vendor dashboard → click **Menu** → add item → appears in list
- [ ] Edit item → fields pre-fill → save → list updates
- [ ] Toggle availability → badge flips between Available / Unavailable
- [ ] Click settings gear → update shop name → save → confirm change
- [ ] Danger zone → clear menu → all items removed
- [ ] Log out → redirects to home page
- [ ] Register new account → starts as customer → role switcher shows "+ Add" for vendor/delivery with confirmation dialog
- [ ] Switch to vendor role → confirm dialog → role persists after logout/login
- [ ] Vendors page shows no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)